### PR TITLE
Restore v3 installed PWA migration path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@
 
 - Use `npm run serve:preview` for authoritative offline and service-worker review.
 - Reload once after the first online visit so the installed service worker controls the page.
+- Keep `public/service-worker.js` deployed as the documented `v3.0.4` migration bridge until a later owner-approved cleanup.
+- Follow `docs/releases/PWA-MIGRATION.md` when verifying an installed `v3.0.4` upgrade. Do not clear site data because IndexedDB history is device-local.
 - `npm run serve` remains the fast development path, not the production PWA verification path.
 
 ## Release Cutover

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is a web app meant to display HIIT workout program
 - RFCs live in `docs/rfcs/`.
 - ADRs live in `docs/adr/`.
 - Milestone specs live in `docs/specs/`.
-- `main` is the accepted long-term production branch, but the remote default branch should not change until GitHub Pages deployment is implemented and verified.
+- `main` is the production and default branch. GitHub Pages deploys its checked artifact from the `CI` workflow.
 
 ### Features
 
@@ -115,6 +115,8 @@ The app will now be installed and accessible from your home screen like a native
 
 Vite generates the service worker and Workbox precache manifest during `npm run build`. The precache includes the app shell, workout data, exercise metadata, manifest, icons, and hashed build assets. Tailwind CSS and Toastify are bundled locally so core UI rendering does not require a CDN.
 
+`public/service-worker.js` is a compatibility bridge for installed `v3.0.4` PWAs. Keep it deployed at the legacy URL while those clients migrate. It deletes only stale `hiit-app-cache-v*` shell caches and does not touch IndexedDB. The generated Workbox worker remains `/sw.js`.
+
 Use the production preview when reviewing offline behavior:
 
 ```bash
@@ -127,6 +129,12 @@ If you encounter issues, ensure that:
 1. The service worker is correctly registered in the browser's DevTools under **Application > Service Workers**.
 2. You are accessing the app over HTTP or HTTPS, as service workers only work on secure origins.
 3. You reload once after the first online visit so the installed service worker controls the page.
+
+### Updating An Installed v3.0.4 PWA
+
+Users with an installed `v3.0.4` PWA should open the app online once, close it, and reopen it. The legacy worker bridge releases the stale cached shell so the v4 app can load and register `/sw.js`.
+
+Do not ask users to clear site data or reinstall the PWA. Saved workout history is device-local IndexedDB data. See the [installed PWA migration runbook](docs/releases/PWA-MIGRATION.md).
 
 ### UI Structure
 
@@ -143,7 +151,7 @@ Shared visual tokens and component classes live in `src/styles.css`. Calendar-sa
 
 ### GitHub Pages Deployment
 
-The `CI` workflow keeps pull requests and `staging` pushes check-only. A push to `main` deploys the GitHub Pages artifact only after lint, formatting, typecheck, unit tests, production build verification, mobile end-to-end tests, and PWA offline tests pass.
+The `CI` workflow keeps pull requests and `staging` pushes check-only. GitHub Pages is configured to use GitHub Actions. A push to `main` deploys the GitHub Pages artifact only after lint, formatting, typecheck, unit tests, production build verification, mobile end-to-end tests, and PWA offline tests pass.
 
 The workflow builds the repository-path artifact with:
 
@@ -151,21 +159,15 @@ The workflow builds the repository-path artifact with:
 npm run build:pages
 ```
 
-One repository setting must be changed manually after the workflow is reviewed and merged:
-
-1. Open **Settings > Pages**.
-2. Under **Build and deployment**, set **Source** to **GitHub Actions**.
-3. Run the `CI` workflow from `main` or merge a reviewed change into `main`.
-4. Confirm the `github-pages` environment deployment succeeds.
-
-Until that source switch is made, the production site continues using the legacy `main` branch-root publishing configuration.
+Confirm the `github-pages` environment deployment succeeds after each reviewed `main` merge. The initial manual **Settings > Pages > Build and deployment > Source > GitHub Actions** switch was completed during the v4 cutover.
 
 ### Releases
 
-Use the [release checklist](docs/releases/RELEASE-CHECKLIST.md) for the final refactor cutover. The [rollback runbook](docs/releases/ROLLBACK.md) records the protected pre-refactor production baseline and recovery steps.
+Use the [release checklist](docs/releases/RELEASE-CHECKLIST.md) for the final refactor cutover. The [installed PWA migration runbook](docs/releases/PWA-MIGRATION.md) covers existing `v3.0.4` installs. The [rollback runbook](docs/releases/ROLLBACK.md) records the protected pre-refactor production baseline and recovery steps.
 
 - Release the completed refactor as `v4.0.0`.
 - Include user-visible changes, migration notes, and known issues.
+- Keep the legacy PWA migration bridge deployed until a later owner-approved cleanup.
 - Verify install and update behavior manually in iPhone Safari before publishing a release.
-- Switch the GitHub Pages source, merge into `main`, verify production, and change the default branch in separate owner-approved steps.
+- Keep each future production merge, tag, release, and cleanup action behind explicit owner approval.
 - Keep `staging` available until a later owner-approved cleanup.

--- a/docs/releases/PWA-MIGRATION.md
+++ b/docs/releases/PWA-MIGRATION.md
@@ -1,0 +1,59 @@
+# Installed PWA Migration: v3.0.4 To v4.0.0
+
+Keep this compatibility path deployed while installed `v3.0.4` clients migrate to
+`v4.0.0`.
+
+## Why The Bridge Exists
+
+The legacy app registered `/hiit-web-app/service-worker.js` and served its cached
+shell before checking the network. The refactored app registers the generated
+Workbox worker at `/hiit-web-app/sw.js`.
+
+Removing the legacy URL immediately can leave an installed `v3.0.4` PWA on its
+cached shell indefinitely. The compatibility bridge restores the old URL long
+enough for those installs to move forward.
+
+## Bridge Behavior
+
+`public/service-worker.js` is intentionally small:
+
+- Activate immediately when a legacy registration discovers it.
+- Delete only caches whose names start with `hiit-app-cache-v`.
+- Claim existing clients.
+- Do not register a `fetch` handler.
+- Do not read, write, delete, or migrate IndexedDB.
+
+Without a fetch handler, the next normal launch loads the network-hosted v4 shell.
+The v4 shell then registers `/hiit-web-app/sw.js` for future generated Workbox
+updates.
+
+## Existing User Flow
+
+Users with an installed `v3.0.4` PWA should:
+
+1. Open the installed app while online.
+2. Close the app after it finishes loading.
+3. Reopen the installed app.
+4. Confirm the footer reports `v4.0.0`.
+
+Users should not clear site data or reinstall the PWA. Clearing site data can
+delete device-local saved-weight history.
+
+## Release Verification
+
+Before publishing the `v4.0.0` tag and GitHub Release:
+
+1. Confirm `/hiit-web-app/service-worker.js` returns `200`.
+2. Confirm `/hiit-web-app/sw.js` returns `200`.
+3. Start from a browser profile or installed PWA controlled by the legacy worker.
+4. Retain or seed a legacy-compatible `{ id, weight, date }` IndexedDB record.
+5. Open online once, close, and reopen.
+6. Confirm the footer reports `v4.0.0`.
+7. Confirm retained History and Last Weight values remain readable.
+8. Confirm a new saved weight remains readable after reload.
+9. Confirm offline core routes still work after the v4 worker takes control.
+
+## Retention
+
+Keep the bridge deployed after the initial release. Remove it only in a later
+owner-approved cleanup after the migration window is intentionally closed.

--- a/docs/releases/RELEASE-CHECKLIST.md
+++ b/docs/releases/RELEASE-CHECKLIST.md
@@ -11,9 +11,9 @@ Do not perform any remote write unless the owner explicitly approves that step.
 - [x] Rollback reference strategy selected: immutable tag and rollback branch.
 - [x] Remote rollback references approved for creation.
 - [x] Pull request into `main` approved for creation.
-- [ ] GitHub Pages source switch approved.
-- [ ] Merge into `main` approved.
-- [ ] Default-branch switch from `staging` to `main` approved.
+- [x] GitHub Pages source switch approved and completed.
+- [x] Merge into `main` approved and completed.
+- [x] Remote default branch verified as `main`.
 - [ ] Tag and GitHub Release publication approved.
 
 ## Local Release Candidate
@@ -43,7 +43,7 @@ Do not perform any remote write unless the owner explicitly approves that step.
   ```
 
 - [ ] Run `git diff --check`.
-- [ ] Serve the production preview and confirm `/`, `/sw.js`, and `/manifest.webmanifest` return `200`.
+- [ ] Serve the production preview and confirm `/`, `/service-worker.js`, `/sw.js`, and `/manifest.webmanifest` return `200`.
 - [ ] Confirm Home, Directory, History, direct workout, rest-day, and not-found states.
 - [ ] Confirm Easy Scroll positions Directory near the current week once and still allows manual browsing.
 - [ ] Confirm Multi Workout offers the previous two scheduled workouts across rest days and supports add, save, History, and remove behavior.
@@ -70,6 +70,9 @@ Do not perform any remote write unless the owner explicitly approves that step.
 - [ ] Switch offline and verify core routes, Multi Workout, saves, and History.
 - [ ] Verify a clean-load update activates.
 - [ ] Verify unsaved weight text defers a waiting-version reload until the app becomes clean.
+- [ ] Follow [`PWA-MIGRATION.md`](./PWA-MIGRATION.md) from a legacy-worker profile or installed `v3.0.4` PWA.
+- [ ] Confirm the legacy bridge removes stale shell caches without deleting retained IndexedDB history.
+- [ ] Confirm the migrated app reports `v4.0.0` after opening online once, closing, and reopening.
 
 ## Controlled Cutover
 
@@ -78,12 +81,14 @@ Do not perform any remote write unless the owner explicitly approves that step.
 - [x] Push the reviewed release-candidate branch.
 - [x] Open the approved pull request into `main`.
 - [x] Confirm pull-request checks pass.
-- [ ] Change **Settings > Pages > Build and deployment > Source** to **GitHub Actions**.
-- [ ] Merge the approved pull request into `main`.
-- [ ] Confirm the `CI` checks, Pages artifact build, and `github-pages` deployment succeed.
-- [ ] Verify `https://yourfriendfitz.github.io/hiit-web-app/`.
+- [x] Change **Settings > Pages > Build and deployment > Source** to **GitHub Actions**.
+- [x] Merge the approved pull request into `main`.
+- [x] Confirm the `CI` checks, Pages artifact build, and `github-pages` deployment succeed.
+- [x] Verify `https://yourfriendfitz.github.io/hiit-web-app/`.
+- [ ] Merge and deploy the reviewed PWA migration bridge hotfix.
+- [ ] Confirm production `/hiit-web-app/service-worker.js` and `/hiit-web-app/sw.js` return `200`.
 - [ ] Repeat the production storage-upgrade and PWA smoke checks.
-- [ ] Change the repository default branch from `staging` to `main`.
+- [x] Confirm the repository default branch is `main`.
 - [ ] Publish the approved `v4.0.0` tag and GitHub Release.
 - [ ] Keep `staging` available until a later owner-approved cleanup.
 
@@ -93,4 +98,5 @@ Do not perform any remote write unless the owner explicitly approves that step.
 - [ ] State that IndexedDB remains compatible.
 - [ ] Record manual production checks.
 - [ ] Record known issues, or state `None known`.
+- [ ] Link [`PWA-MIGRATION.md`](./PWA-MIGRATION.md).
 - [ ] Link [`ROLLBACK.md`](./ROLLBACK.md).

--- a/docs/releases/ROLLBACK.md
+++ b/docs/releases/ROLLBACK.md
@@ -39,3 +39,4 @@ Rollback is appropriate when production verification finds a release-blocking is
 - Do not force-push or rewrite shared history.
 - Do not delete remote branches during rollback.
 - Do not publish a release tag until production verification succeeds.
+- Do not remove the legacy PWA migration bridge during the initial v4 rollout.

--- a/docs/releases/v4.0.0.md
+++ b/docs/releases/v4.0.0.md
@@ -1,6 +1,6 @@
 # v4.0.0 Release Notes
 
-Status: Release candidate
+Status: Release candidate; PWA migration bridge hotfix required before publication
 
 ## Summary
 
@@ -11,6 +11,7 @@ Status: Release candidate
 - Updated mobile-first training interface with reachable bottom navigation and compact workout cards.
 - Searchable saved-weight History and free-text weight entry remain available.
 - Generated PWA assets improve offline reliability and apply updates on a clean load without discarding unsaved weight text.
+- Existing installed `v3.0.4` PWAs migrate through a compatibility bridge without clearing device-local history.
 - Directory opens near the current training week while remaining freely browsable.
 - Home can add one of the previous two scheduled workouts while skipping rest days.
 
@@ -25,6 +26,12 @@ Existing local history remains compatible:
 
 No IndexedDB migration is included or required.
 
+## Installed PWA Upgrade
+
+The legacy app registered `/hiit-web-app/service-worker.js`; the refactored app registers the generated worker at `/hiit-web-app/sw.js`. Keep the compatibility bridge at the legacy URL so installed `v3.0.4` clients can release their stale cached shell.
+
+Existing users should open the installed app online once, close it, and reopen it. They should not clear site data or reinstall the PWA. Follow [`PWA-MIGRATION.md`](./PWA-MIGRATION.md) for the verification sequence and bridge-retention policy.
+
 ## Verification
 
 Local release-candidate verification completed:
@@ -35,18 +42,21 @@ Local release-candidate verification completed:
 - Historical records with an unknown exercise ID remain visible and searchable by raw ID.
 - A new free-text saved weight survived reload and remained visible alongside legacy history.
 - New saves use stable `N/A` text when optional RPE context is absent.
+- The Pages artifact includes the migration-only legacy `/service-worker.js` bridge with no fetch handler.
+- Chromium PWA regression coverage confirms the bridge removes stale `hiit-app-cache-v*` shell caches, retains unrelated caches, and preserves seeded IndexedDB history.
 - Home rest-day, Directory current-week positioning, and Multi Workout mobile probes pass without horizontal overflow.
 
 Production and physical-device checks remain required before publication:
 
 - GitHub Pages Actions deployment from `main`.
+- Production deployment and verification of the legacy PWA migration bridge.
 - Existing device-local IndexedDB history after production upgrade.
 - iPhone Safari install, offline, and clean-load update behavior.
 - Chrome mobile core-route and saved-weight behavior.
 
 ## Known Issues
 
-None known from local release-candidate verification.
+The initial v4 cutover omitted the legacy `/hiit-web-app/service-worker.js` URL required by installed `v3.0.4` clients. The reviewed migration bridge hotfix must deploy before publishing the `v4.0.0` tag or GitHub Release.
 
 ## Rollback
 

--- a/docs/specs/0004-pwa-and-github-pages-deployment.md
+++ b/docs/specs/0004-pwa-and-github-pages-deployment.md
@@ -18,7 +18,7 @@ Related ADRs:
 
 ## Summary
 
-Replace the retained hand-written service worker with generated Workbox precaching through `vite-plugin-pwa` and bundle browser runtime dependencies into the Vite build.
+Replace the retained hand-written service worker with generated Workbox precaching through `vite-plugin-pwa` and bundle browser runtime dependencies into the Vite build. Keep a migration-only compatibility worker at the legacy URL during the v4 rollout so installed `v3.0.4` clients can release their stale cache-first shell.
 
 The generated service worker must make the app shell, workout data, exercise metadata, and device-local weight workflows available offline after the first visit. Updates must be discovered automatically, but applying an update must be deferred while a user has unsaved weight input.
 
@@ -53,7 +53,7 @@ GitHub Actions deployment setup was explicitly deferred until after the runtime 
 - Add `vite-plugin-pwa` `1.3.x` and use its Workbox `generateSW` strategy.
 - Configure Vite PWA assets and a generated web app manifest from the existing app metadata and icon files.
 - Precache generated HTML, hashed JavaScript, hashed CSS, workout JSON, exercise JSON, manifest, and local icon assets.
-- Replace the custom `public/service-worker.js`.
+- Replace the custom cache-first `public/service-worker.js` with a migration-only bridge during the v4 rollout. The generated Workbox worker remains `/sw.js`.
 - Remove obsolete legacy runtime modules from `public/` after confirming the generated build does not reference them.
 - Replace manual service-worker registration with an explicit registration module using `virtual:pwa-register`.
 - Check for service-worker updates on app load and when the document becomes visible.
@@ -130,6 +130,7 @@ Update policy:
 - Do not force a reload while weight input contains unsaved text.
 - Apply a waiting version on the next clean load or once the app becomes clean.
 - Avoid an update loop by reloading at most once after a successful activation.
+- Keep `/service-worker.js` free of fetch interception; it exists only to clear `hiit-app-cache-v*` caches for legacy installed clients without touching IndexedDB.
 
 ## Files Likely Touched
 
@@ -151,7 +152,7 @@ Update policy:
 - `npm run build` generates a Workbox-backed service worker with a hashed precache manifest.
 - The generated Pages build uses `/hiit-web-app/` as its base path.
 - The production HTML has no Tailwind CDN, Toastify CDN, or Google Fonts dependency.
-- Obsolete hand-written service-worker and legacy runtime files are removed when no longer referenced.
+- Obsolete legacy runtime files are removed when no longer referenced. `/service-worker.js` remains temporarily as a migration-only bridge.
 - After one online visit, the app shell loads offline.
 - Today's workout, directory, workout detail, and history routes load offline.
 - Existing IndexedDB weight records remain readable offline.
@@ -170,6 +171,7 @@ Update policy:
 - Unit test: clean state allows a waiting service-worker update to apply.
 - Unit test: dirty state defers a waiting service-worker update until the state clears.
 - Build assertion: generated `dist/` contains the service worker, web manifest, workout data, exercise metadata, icons, and hashed asset references.
+- Build assertion: `dist/service-worker.js` remains a migration-only bridge with no fetch handler.
 - Build assertion: generated HTML has no Tailwind CDN, Toastify CDN, or Google Fonts URL.
 - Playwright Chromium PWA test: visit online, wait for service-worker control, switch offline, reload, and verify the home route renders.
 - Playwright Chromium PWA test: navigate to directory, workout detail, and history while offline.
@@ -216,6 +218,7 @@ Research checked at `2026-05-30T12:14:33-05:00`.
 ## Decision Log
 
 - Use generated Workbox precaching through `vite-plugin-pwa` instead of maintaining a service worker cache list manually.
+- Retain a migration-only `/service-worker.js` bridge until a later owner-approved cleanup so installed `v3.0.4` registrations can advance to the generated `/sw.js` worker without clearing IndexedDB.
 - Use explicit update readiness callbacks and app dirty-state tracking instead of unconditional immediate reload behavior.
 - Bundle Tailwind CSS and Toastify locally.
 - Use the system font stack to eliminate a core-rendering network dependency without adding font artifacts.

--- a/docs/specs/0008-stabilization-and-v4-release.md
+++ b/docs/specs/0008-stabilization-and-v4-release.md
@@ -20,7 +20,7 @@ Related ADRs:
 
 Stabilize the completed refactor, document the production cutover, and release the checked application as the new GitHub Pages baseline. This milestone does not introduce a product feature. It closes remaining release-readiness gaps, performs the full automated and manual regression pass, verifies IndexedDB upgrade safety, and executes a controlled Pages transition only after explicit owner approval.
 
-The remote repository currently keeps `staging` as its default branch and publishes GitHub Pages from the legacy `main` branch root. Milestone 4 added the checked GitHub Actions Pages workflow but intentionally left the repository settings unchanged. This milestone completes that deferred cutover, verifies production, changes the default branch to `main` after Pages is stable, and publishes the approved release.
+The checked GitHub Actions Pages cutover from `main` is complete, and the remote default branch now reports `main`. Production verification then found one release-blocking compatibility gap before tag publication: installed `v3.0.4` PWAs still request `/hiit-web-app/service-worker.js`, while the generated v4 worker is `/hiit-web-app/sw.js`. This milestone adds a narrow migration bridge at the legacy URL before publishing the approved release.
 
 ## Goals
 
@@ -32,6 +32,7 @@ The remote repository currently keeps `staging` as its default branch and publis
 - Switch GitHub Pages from legacy branch-root publishing to the reviewed GitHub Actions workflow only after explicit owner approval.
 - Move the remote default branch from `staging` to `main` only after the production Pages deployment is verified.
 - Publish the approved Git tag and GitHub Release after production verification.
+- Keep installed `v3.0.4` PWAs upgradeable without clearing device-local data or reinstalling.
 
 ## Non-Goals
 
@@ -56,8 +57,9 @@ The remote repository currently keeps `staging` as its default branch and publis
 - Run the GitHub Pages repository-path build from the clean image.
 - Run `actionlint` against the deployment workflow.
 - Confirm `git diff --check` remains clean.
-- Confirm the production preview returns `200` for `/`, `/sw.js`, and `/manifest.webmanifest`.
+- Confirm the production preview returns `200` for `/`, `/service-worker.js`, `/sw.js`, and `/manifest.webmanifest`.
 - Confirm the generated Pages artifact references `/hiit-web-app/` paths and includes the generated manifest and service worker.
+- Confirm the Pages artifact retains `/service-worker.js` as a migration-only bridge for legacy installed clients.
 - Confirm workout data and exercise metadata contract tests still pass without source-content edits.
 - Fix only release-blocking regressions discovered during this audit.
 - Keep historical records visible and searchable by raw exercise ID when current exercise metadata no longer contains that ID.
@@ -75,6 +77,7 @@ The remote repository currently keeps `staging` as its default branch and publis
   - Rollback reference.
 - Update contributor and deployment documentation so the final branch, Pages source, verification sequence, and release procedure are current.
 - Record the pre-refactor production baseline commit `2ef93c0cc5db8b4cad6ced6311434a62bad0e75a` in the rollback instructions.
+- Add an installed-PWA migration runbook covering user steps, operator verification, and bridge retention.
 
 ### Manual Upgrade Verification
 
@@ -96,6 +99,11 @@ The remote repository currently keeps `staging` as its default branch and publis
   - Save and read weights offline.
   - Confirm a newly deployed version activates on a clean app load.
   - Confirm unsaved weight text defers a waiting-version reload until the form becomes clean.
+- Verify the legacy installed-PWA bridge:
+  - Start from a profile or installed app controlled by the `v3.0.4` worker.
+  - Retain or seed legacy-compatible IndexedDB history.
+  - Open online once, close, and reopen.
+  - Confirm v4 loads, retained history remains readable, and future updates use `/sw.js`.
 - Verify Chrome mobile behavior for the same core routes and saved-weight flow.
 
 ### Controlled Production Cutover
@@ -117,6 +125,8 @@ After approval:
 
 Do not delete `staging` during this milestone. Retire it only in a separate owner-approved cleanup after production has remained stable.
 
+Before step 10, deploy and verify the reviewed migration bridge hotfix. The bridge must remain deployed after publication until a later owner-approved cleanup closes the legacy-client migration window.
+
 ## Out Of Scope
 
 - New product features.
@@ -130,13 +140,13 @@ Do not delete `staging` during this milestone. Retire it only in a separate owne
 
 ## User Impact
 
-Users receive the refactored mobile-first app at the existing GitHub Pages URL. Existing local weight history remains available. The release includes reliable offline behavior, safer PWA updates, the current-week Directory position, and the Home missed-workout quick-add workflow.
+Users receive the refactored mobile-first app at the existing GitHub Pages URL. Existing local weight history remains available. The release includes reliable offline behavior, safer PWA updates, the current-week Directory position, and the Home missed-workout quick-add workflow. Installed `v3.0.4` clients can advance by opening online once, closing, and reopening.
 
 The cutover must not require users to clear browser data, reinstall the PWA, or recreate saved weight history.
 
 ## Architecture Impact
 
-No architecture change is planned. The milestone may make narrowly scoped fixes if the release audit finds a blocker.
+The generated `/sw.js` Workbox architecture remains unchanged. A migration-only compatibility worker is retained at `/service-worker.js` so installed `v3.0.4` registrations can delete stale legacy shell caches and release fetch interception. The bridge does not handle fetch events and does not touch IndexedDB.
 
 Expected documentation work:
 
@@ -169,7 +179,7 @@ The release must be verified against seeded or retained legacy-compatible record
 
 ## Offline And PWA Impact
 
-No service-worker strategy change is planned. The milestone verifies the generated Workbox precache, repository-path Pages artifact, offline route behavior, offline IndexedDB saves, and deferred waiting-version activation policy.
+The generated Workbox service-worker strategy remains unchanged. The milestone verifies the generated Workbox precache, repository-path Pages artifact, offline route behavior, offline IndexedDB saves, deferred waiting-version activation policy, and the migration-only bridge served at the legacy `/service-worker.js` URL.
 
 If a release-blocking PWA defect is discovered, fix it narrowly and extend the existing PWA regression test before cutover.
 
@@ -186,6 +196,8 @@ If a release-blocking PWA defect is discovered, fix it narrowly and extend the e
 - `package-lock.json`
 - `.github/workflows/ci.yml`
 - `tests/**`
+- `public/service-worker.js`
+- `scripts/assert-pwa-build.mjs`
 
 Only touch workflow, source, or test files when a version alignment or verified release blocker requires it.
 
@@ -207,6 +219,9 @@ Only touch workflow, source, or test files when a version alignment or verified 
 - `git diff --check` passes.
 - The release candidate is reviewed before any production mutation.
 - After explicit owner-approved cutover, GitHub Pages deploys from GitHub Actions on `main`.
+- The Pages artifact serves both `/service-worker.js` and `/sw.js`; the legacy bridge has no fetch handler.
+- The legacy bridge deletes only `hiit-app-cache-v*` caches and preserves IndexedDB history.
+- An installed `v3.0.4` client can load v4 after opening online once, closing, and reopening without clearing site data or reinstalling.
 - The production GitHub Pages URL passes smoke, IndexedDB upgrade, PWA install/offline, and update verification.
 - The repository default branch changes from `staging` to `main` only after production verification.
 - The approved release tag and GitHub Release are published after production verification.
@@ -220,6 +235,8 @@ Only touch workflow, source, or test files when a version alignment or verified 
 - Existing Vitest calendar-safe current-week and recent-workout suite remains green.
 - Existing mobile Chromium and WebKit Home, Directory, History, Easy Scroll, Multi Workout, storage, toast, and listener-cleanup suites remain green.
 - Existing Chromium service-worker-controlled offline route, Multi Workout, and saved-weight suite remains green.
+- Chromium PWA coverage verifies the legacy bridge deletes stale shell caches, retains an unrelated control cache, and preserves a seeded IndexedDB history record.
+- Build verification requires the migration bridge, immediate activation, client claiming, the legacy-cache prefix, and the absence of a fetch handler.
 - Mobile browser coverage verifies raw-ID History fallback for records missing current metadata.
 - Mobile browser coverage verifies stable `N/A` text when optional RPE context is absent.
 - Clean-image `npm run build:pages` verifies the GitHub Pages repository-path artifact.
@@ -231,7 +248,7 @@ Only touch workflow, source, or test files when a version alignment or verified 
 ### Local Release Candidate
 
 - Build and serve the Docker production preview.
-- Confirm `/`, `/sw.js`, and `/manifest.webmanifest` return `200`.
+- Confirm `/`, `/service-worker.js`, `/sw.js`, and `/manifest.webmanifest` return `200`.
 - Confirm the Home scheduled-day, Home rest-day, Directory, History, direct workout, not-found, and offline states.
 - Confirm no phone viewport has horizontal overflow or bottom-navigation overlap.
 - Confirm Easy Scroll lands near the current week once and does not prevent manual browsing.
@@ -239,6 +256,7 @@ Only touch workflow, source, or test files when a version alignment or verified 
 - Confirm a dirty weight input still defers a waiting update.
 - Confirm seeded legacy-compatible IndexedDB records remain readable and new records remain writable.
 - Confirm a retained record with an unknown exercise ID remains visible and searchable by raw ID.
+- Confirm the migration bridge clears only `hiit-app-cache-v*` caches and retains IndexedDB history.
 
 ### Device And Production
 
@@ -253,6 +271,7 @@ Only touch workflow, source, or test files when a version alignment or verified 
 - Confirm the GitHub Pages deployment succeeds.
 - Reload the production URL and verify Home, Directory, History, Easy Scroll, Multi Workout, and weight history.
 - Confirm existing device-local weight records remain readable after the production update.
+- From an installed `v3.0.4` PWA, open online once, close, reopen, and confirm footer `v4.0.0`.
 - Confirm a clean-load update is applied without discarding unsaved weight text.
 - Change the remote default branch to `main`.
 - Publish the approved tag and GitHub Release.
@@ -291,3 +310,5 @@ Do not clear IndexedDB, ask users to clear site data, rewrite history destructiv
 - Switch Pages to GitHub Actions before merging the approved release candidate into `main`.
 - Verify production before changing the repository default branch from `staging` to `main`.
 - Keep `staging` available until separate cleanup approval.
+- Keep the migration bridge at `/service-worker.js` until a later owner-approved cleanup.
+- Serve the migration bridge without a fetch handler so the next normal launch can load the v4 shell while IndexedDB remains untouched.

--- a/public/service-worker.js
+++ b/public/service-worker.js
@@ -1,0 +1,21 @@
+const LEGACY_CACHE_PREFIX = "hiit-app-cache-v";
+
+// Keep this bridge at the legacy URL until installed 3.0.4 clients have migrated.
+self.addEventListener("install", (event) => {
+  event.waitUntil(self.skipWaiting());
+});
+
+self.addEventListener("activate", (event) => {
+  event.waitUntil(
+    caches
+      .keys()
+      .then((cacheNames) =>
+        Promise.all(
+          cacheNames
+            .filter((cacheName) => cacheName.startsWith(LEGACY_CACHE_PREFIX))
+            .map((cacheName) => caches.delete(cacheName)),
+        ),
+      )
+      .then(() => self.clients.claim()),
+  );
+});

--- a/scripts/assert-pwa-build.mjs
+++ b/scripts/assert-pwa-build.mjs
@@ -11,6 +11,7 @@ const requiredFiles = [
   "favicon.ico",
   "index.html",
   "manifest.webmanifest",
+  "service-worker.js",
   "sw.js",
 ];
 const removedLegacyFiles = [
@@ -20,7 +21,6 @@ const removedLegacyFiles = [
   "app.js",
   "manifest.json",
   "register.js",
-  "service-worker.js",
   "styles.css",
 ];
 
@@ -41,6 +41,10 @@ for (const fileName of removedLegacyFiles) {
 }
 
 const html = readFileSync(new URL("index.html", distPath), "utf8");
+const legacyMigrationWorker = readFileSync(
+  new URL("service-worker.js", distPath),
+  "utf8",
+);
 const serviceWorker = readFileSync(new URL("sw.js", distPath), "utf8");
 const assetNames = readdirSync(new URL("assets/", distPath));
 
@@ -77,6 +81,24 @@ for (const fileName of [
 
 if (!serviceWorker.includes("SKIP_WAITING")) {
   fail("sw.js does not expose explicit update activation messaging");
+}
+
+if (
+  !legacyMigrationWorker.includes('LEGACY_CACHE_PREFIX = "hiit-app-cache-v"')
+) {
+  fail("service-worker.js does not target legacy shell caches");
+}
+
+if (!legacyMigrationWorker.includes("self.skipWaiting()")) {
+  fail("service-worker.js does not activate the migration bridge immediately");
+}
+
+if (!legacyMigrationWorker.includes("self.clients.claim()")) {
+  fail("service-worker.js does not claim legacy clients");
+}
+
+if (/addEventListener\(["']fetch["']/.test(legacyMigrationWorker)) {
+  fail("service-worker.js migration bridge must not intercept fetch requests");
 }
 
 console.log(`Verified generated PWA build in ${join(distPath.pathname, "")}`);

--- a/tests/pwa/offline.spec.js
+++ b/tests/pwa/offline.spec.js
@@ -83,41 +83,56 @@ test("loads core routes and saves a weight offline after the first visit", async
 test("legacy migration bridge removes stale shell caches without deleting IndexedDB history", async ({
   page,
 }) => {
-  await page.goto("/");
-  await page.evaluate(async () => {
-    await navigator.serviceWorker.ready;
-    const registrations = await navigator.serviceWorker.getRegistrations();
-    await Promise.all(
-      registrations.map((registration) => registration.unregister()),
-    );
+  await prepareOfflineApp(page);
+  await Promise.all([
+    page.waitForEvent("framenavigated"),
+    page.evaluate(async () => {
+      const registrations = await navigator.serviceWorker.getRegistrations();
+      await Promise.all(
+        registrations.map((registration) => registration.unregister()),
+      );
 
-    const legacyCache = await caches.open("hiit-app-cache-v3.0.4");
-    await legacyCache.put("/legacy-index.html", new Response("legacy shell"));
-    const controlCache = await caches.open("migration-control-cache");
-    await controlCache.put("/retain.html", new Response("retain"));
+      const legacyCache = await caches.open("hiit-app-cache-v3.0.4");
+      await legacyCache.put("/legacy-index.html", new Response("legacy shell"));
+      const controlCache = await caches.open("migration-control-cache");
+      await controlCache.put("/retain.html", new Response("retain"));
 
-    await new Promise((resolve, reject) => {
-      const request = indexedDB.open("hiit-app-db", 1);
+      await new Promise((resolve, reject) => {
+        const request = indexedDB.open("hiit-app-db", 1);
 
-      request.onsuccess = () => {
-        const db = request.result;
-        const transaction = db.transaction("Weights", "readwrite");
-        transaction.objectStore("Weights").put({
-          id: "migration-probe",
-          weight: "Legacy 135",
-          date: new Date("2026-05-01T12:00:00-05:00"),
-        });
-        transaction.oncomplete = () => {
-          db.close();
-          resolve();
+        request.onupgradeneeded = () => {
+          const db = request.result;
+          if (!db.objectStoreNames.contains("Weights")) {
+            const store = db.createObjectStore("Weights", {
+              autoIncrement: true,
+            });
+            store.createIndex("id", "id", { unique: false });
+            store.createIndex("date", "date", { unique: false });
+            store.createIndex("weight", "weight", { unique: false });
+          }
         };
-        transaction.onerror = () => reject(transaction.error);
-      };
-      request.onerror = () => reject(request.error);
-    });
 
-    await navigator.serviceWorker.register("/service-worker.js");
-  });
+        request.onsuccess = () => {
+          const db = request.result;
+          const transaction = db.transaction("Weights", "readwrite");
+          transaction.objectStore("Weights").put({
+            id: "migration-probe",
+            weight: "Legacy 135",
+            date: new Date("2026-05-01T12:00:00-05:00"),
+          });
+          transaction.oncomplete = () => {
+            db.close();
+            resolve();
+          };
+          transaction.onerror = () => reject(transaction.error);
+        };
+        request.onerror = () => reject(request.error);
+      });
+
+      await navigator.serviceWorker.register("/service-worker.js");
+    }),
+  ]);
+  await page.waitForLoadState("domcontentloaded");
 
   await expect
     .poll(() =>

--- a/tests/pwa/offline.spec.js
+++ b/tests/pwa/offline.spec.js
@@ -79,3 +79,85 @@ test("loads core routes and saves a weight offline after the first visit", async
   await expect(page.getByText(/Offline 145/)).toBeVisible();
   await expect(page.getByText(/Offline added 125/)).toBeVisible();
 });
+
+test("legacy migration bridge removes stale shell caches without deleting IndexedDB history", async ({
+  page,
+}) => {
+  await page.goto("/");
+  await page.evaluate(async () => {
+    await navigator.serviceWorker.ready;
+    const registrations = await navigator.serviceWorker.getRegistrations();
+    await Promise.all(
+      registrations.map((registration) => registration.unregister()),
+    );
+
+    const legacyCache = await caches.open("hiit-app-cache-v3.0.4");
+    await legacyCache.put("/legacy-index.html", new Response("legacy shell"));
+    const controlCache = await caches.open("migration-control-cache");
+    await controlCache.put("/retain.html", new Response("retain"));
+
+    await new Promise((resolve, reject) => {
+      const request = indexedDB.open("hiit-app-db", 1);
+
+      request.onsuccess = () => {
+        const db = request.result;
+        const transaction = db.transaction("Weights", "readwrite");
+        transaction.objectStore("Weights").put({
+          id: "migration-probe",
+          weight: "Legacy 135",
+          date: new Date("2026-05-01T12:00:00-05:00"),
+        });
+        transaction.oncomplete = () => {
+          db.close();
+          resolve();
+        };
+        transaction.onerror = () => reject(transaction.error);
+      };
+      request.onerror = () => reject(request.error);
+    });
+
+    await navigator.serviceWorker.register("/service-worker.js");
+  });
+
+  await expect
+    .poll(() =>
+      page.evaluate(async () => {
+        const cacheNames = await caches.keys();
+        return {
+          legacyCachePresent: cacheNames.includes("hiit-app-cache-v3.0.4"),
+          controlCachePresent: cacheNames.includes("migration-control-cache"),
+        };
+      }),
+    )
+    .toEqual({
+      legacyCachePresent: false,
+      controlCachePresent: true,
+    });
+
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () =>
+          new Promise((resolve, reject) => {
+            const request = indexedDB.open("hiit-app-db", 1);
+            request.onsuccess = () => {
+              const db = request.result;
+              const transaction = db.transaction("Weights", "readonly");
+              const records = transaction.objectStore("Weights").getAll();
+              records.onsuccess = () => {
+                db.close();
+                resolve(
+                  records.result.some(
+                    ({ id, weight }) =>
+                      id === "migration-probe" && weight === "Legacy 135",
+                  ),
+                );
+              };
+              records.onerror = () => reject(records.error);
+            };
+            request.onerror = () => reject(request.error);
+          }),
+      ),
+    )
+    .toBe(true);
+});


### PR DESCRIPTION
## Summary
- restore `/service-worker.js` as a migration-only bridge for installed `v3.0.4` PWAs
- delete only stale `hiit-app-cache-v*` shell caches while preserving IndexedDB history
- keep generated Workbox `/sw.js` as the v4 worker and avoid fetch interception in the bridge
- document the one-time online open, close, and reopen flow plus bridge-retention policy

## Why
The initial v4 Pages cutover removed the legacy worker URL. Existing installed `v3.0.4` PWAs remain registered to `/hiit-web-app/service-worker.js`, and their cache-first worker can continue serving the legacy shell. This bridge allows those clients to advance without clearing site data or reinstalling.

## Verification
- `docker run --rm hiit-web-app-checks`
- `docker run --rm hiit-web-app-checks npm run build:pages`
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.12`
- `git diff --check`
- local preview returns `200` for `/`, `/service-worker.js`, `/sw.js`, and `/manifest.webmanifest`
- Chromium PWA regression confirms stale legacy cache cleanup, unrelated cache retention, and seeded IndexedDB history preservation

## Release Gate
Merge and deploy this hotfix before publishing the `v4.0.0` tag or GitHub Release. Keep the bridge deployed until a later owner-approved cleanup.