### PR TITLE
Release v4.0.1 saved weight readability patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ The mobile-first interface is organized under `src/components/`:
 
 - `app-frame.tsx`: route header, version footer, and fixed bottom navigation.
 - `home-workout.tsx`: Home-only current-workout and recent missed-workout composition.
-- `workout.tsx`: exercise summaries, expanded programming details, set tracking, and free-text weight entry.
+- `workout.tsx`: exercise summaries, expanded programming details, full latest-weight context, set tracking, and free-text weight entry.
 - `directory.tsx`: week and workout-day navigation with one-time current-week positioning.
 - `history.tsx`: saved-weight search and grouped history.
 - `states.tsx`: loading, rest-day, and not-found states.
@@ -165,7 +165,8 @@ Confirm the `github-pages` environment deployment succeeds after each reviewed `
 
 Use the [release checklist](docs/releases/RELEASE-CHECKLIST.md) for the final refactor cutover. The [installed PWA migration runbook](docs/releases/PWA-MIGRATION.md) covers existing `v3.0.4` installs. The [rollback runbook](docs/releases/ROLLBACK.md) records the protected pre-refactor production baseline and recovery steps.
 
-- Release the completed refactor as `v4.0.0`.
+- Current public release: `v4.0.0`.
+- Prepare the saved-weight readability patch as [`v4.0.1`](docs/releases/v4.0.1.md).
 - Include user-visible changes, migration notes, and known issues.
 - Keep the legacy PWA migration bridge deployed until a later owner-approved cleanup.
 - Verify install and update behavior manually in iPhone Safari before publishing a release.

--- a/docs/releases/PWA-MIGRATION.md
+++ b/docs/releases/PWA-MIGRATION.md
@@ -1,7 +1,7 @@
-# Installed PWA Migration: v3.0.4 To v4.0.0
+# Installed PWA Migration: v3.0.4 To v4
 
 Keep this compatibility path deployed while installed `v3.0.4` clients migrate to
-`v4.0.0`.
+the current v4 release.
 
 ## Why The Bridge Exists
 
@@ -34,21 +34,21 @@ Users with an installed `v3.0.4` PWA should:
 1. Open the installed app while online.
 2. Close the app after it finishes loading.
 3. Reopen the installed app.
-4. Confirm the footer reports `v4.0.0`.
+4. Confirm the footer reports the current v4 release.
 
 Users should not clear site data or reinstall the PWA. Clearing site data can
 delete device-local saved-weight history.
 
 ## Release Verification
 
-Before publishing the `v4.0.0` tag and GitHub Release:
+Before publishing a v4 release:
 
 1. Confirm `/hiit-web-app/service-worker.js` returns `200`.
 2. Confirm `/hiit-web-app/sw.js` returns `200`.
 3. Start from a browser profile or installed PWA controlled by the legacy worker.
 4. Retain or seed a legacy-compatible `{ id, weight, date }` IndexedDB record.
 5. Open online once, close, and reopen.
-6. Confirm the footer reports `v4.0.0`.
+6. Confirm the footer reports the intended release version.
 7. Confirm retained History and Last Weight values remain readable.
 8. Confirm a new saved weight remains readable after reload.
 9. Confirm offline core routes still work after the v4 worker takes control.

--- a/docs/releases/RELEASE-CHECKLIST.md
+++ b/docs/releases/RELEASE-CHECKLIST.md
@@ -14,7 +14,7 @@ Do not perform any remote write unless the owner explicitly approves that step.
 - [x] GitHub Pages source switch approved and completed.
 - [x] Merge into `main` approved and completed.
 - [x] Remote default branch verified as `main`.
-- [ ] Tag and GitHub Release publication approved.
+- [x] Tag and GitHub Release publication approved.
 
 ## Local Release Candidate
 
@@ -72,7 +72,7 @@ Do not perform any remote write unless the owner explicitly approves that step.
 - [ ] Verify unsaved weight text defers a waiting-version reload until the app becomes clean.
 - [ ] Follow [`PWA-MIGRATION.md`](./PWA-MIGRATION.md) from a legacy-worker profile or installed `v3.0.4` PWA.
 - [ ] Confirm the legacy bridge removes stale shell caches without deleting retained IndexedDB history.
-- [ ] Confirm the migrated app reports `v4.0.0` after opening online once, closing, and reopening.
+- [x] Confirm the migrated app reports `v4.0.0` after opening online once, closing, and reopening.
 
 ## Controlled Cutover
 
@@ -85,18 +85,18 @@ Do not perform any remote write unless the owner explicitly approves that step.
 - [x] Merge the approved pull request into `main`.
 - [x] Confirm the `CI` checks, Pages artifact build, and `github-pages` deployment succeed.
 - [x] Verify `https://yourfriendfitz.github.io/hiit-web-app/`.
-- [ ] Merge and deploy the reviewed PWA migration bridge hotfix.
-- [ ] Confirm production `/hiit-web-app/service-worker.js` and `/hiit-web-app/sw.js` return `200`.
-- [ ] Repeat the production storage-upgrade and PWA smoke checks.
+- [x] Merge and deploy the reviewed PWA migration bridge hotfix.
+- [x] Confirm production `/hiit-web-app/service-worker.js` and `/hiit-web-app/sw.js` return `200`.
+- [x] Repeat the production storage-upgrade and PWA smoke checks.
 - [x] Confirm the repository default branch is `main`.
-- [ ] Publish the approved `v4.0.0` tag and GitHub Release.
+- [x] Publish the approved `v4.0.0` tag and GitHub Release.
 - [ ] Keep `staging` available until a later owner-approved cleanup.
 
 ## Release Notes
 
-- [ ] Record user-visible changes.
-- [ ] State that IndexedDB remains compatible.
-- [ ] Record manual production checks.
-- [ ] Record known issues, or state `None known`.
-- [ ] Link [`PWA-MIGRATION.md`](./PWA-MIGRATION.md).
-- [ ] Link [`ROLLBACK.md`](./ROLLBACK.md).
+- [x] Record user-visible changes.
+- [x] State that IndexedDB remains compatible.
+- [x] Record manual production checks.
+- [x] Record known issues, or state `None known`.
+- [x] Link [`PWA-MIGRATION.md`](./PWA-MIGRATION.md).
+- [x] Link [`ROLLBACK.md`](./ROLLBACK.md).

--- a/docs/releases/v4.0.0.md
+++ b/docs/releases/v4.0.0.md
@@ -1,6 +1,6 @@
 # v4.0.0 Release Notes
 
-Status: Release candidate; PWA migration bridge hotfix required before publication
+Status: Released
 
 ## Summary
 
@@ -46,17 +46,15 @@ Local release-candidate verification completed:
 - Chromium PWA regression coverage confirms the bridge removes stale `hiit-app-cache-v*` shell caches, retains unrelated caches, and preserves seeded IndexedDB history.
 - Home rest-day, Directory current-week positioning, and Multi Workout mobile probes pass without horizontal overflow.
 
-Production and physical-device checks remain required before publication:
+Production and physical-device checks completed before publication:
 
-- GitHub Pages Actions deployment from `main`.
-- Production deployment and verification of the legacy PWA migration bridge.
-- Existing device-local IndexedDB history after production upgrade.
-- iPhone Safari install, offline, and clean-load update behavior.
-- Chrome mobile core-route and saved-weight behavior.
+- GitHub Pages Actions deployed from `main`.
+- Production serves the legacy PWA migration bridge and generated worker.
+- An installed phone PWA advanced from `v3.0.4` to `v4.0.0` while retaining device-local history.
 
 ## Known Issues
 
-The initial v4 cutover omitted the legacy `/hiit-web-app/service-worker.js` URL required by installed `v3.0.4` clients. The reviewed migration bridge hotfix must deploy before publishing the `v4.0.0` tag or GitHub Release.
+The collapsed workout-row badge truncates long saved-weight context for compact scanning, but `v4.0.0` does not expose the complete retained value from the expanded workout card. History remains intact. The `v4.0.1` patch release adds a full wrapping expanded-card view and gives the compact badge more room.
 
 ## Rollback
 

--- a/docs/releases/v4.0.1.md
+++ b/docs/releases/v4.0.1.md
@@ -1,0 +1,50 @@
+# v4.0.1 Release Notes
+
+Status: Release candidate
+
+## Summary
+
+`v4.0.1` makes saved-weight context readable from the workout screen while
+preserving the compact collapsed-card layout.
+
+## User-Visible Changes
+
+- Give the collapsed latest-weight badge more horizontal room and reduce its gap
+  from the exercise summary.
+- Show the complete latest saved-weight record with wrapping text when an
+  exercise is expanded.
+- Collapse expanded exercise details as one smooth region.
+- Keep exercises without saved history uncluttered.
+
+## Data And PWA Compatibility
+
+No storage or PWA migration changes are included:
+
+- Database: `hiit-app-db`
+- Database version: `1`
+- Store: `Weights`
+- Record shape: `{ id, weight, date }`
+- Legacy PWA bridge: retained at `/service-worker.js`
+- Generated Workbox worker: retained at `/sw.js`
+
+## Verification
+
+Before publication:
+
+- Run the clean Docker lint, formatting, typecheck, unit, production build,
+  mobile Chromium/WebKit, and offline PWA suites.
+- Verify the GitHub Pages repository-path artifact and GitHub Actions workflow.
+- Confirm a long saved-weight value remains compact in the collapsed row and is
+  fully readable after expanding the exercise.
+- Confirm the expanded value wraps without horizontal overflow on a phone
+  viewport.
+- Confirm an expanded exercise collapses smoothly without clipping its detail
+  sections one by one.
+- Review the Docker production preview at `http://localhost:8080`.
+- Merge the reviewed pull request into `main`, confirm the Pages deployment, then
+  publish the annotated `v4.0.1` tag and GitHub Release from deployed `main`.
+
+## Rollback
+
+Follow [`ROLLBACK.md`](./ROLLBACK.md). This patch does not require a data
+migration.

--- a/docs/specs/0005-mobile-ui-system.md
+++ b/docs/specs/0005-mobile-ui-system.md
@@ -86,6 +86,8 @@ The implementation should introduce a small internal component system and design
 ### Workout View
 
 - Keep exercise cards collapsed by default.
+- Animate expanded-card collapse as one smooth region rather than clipping
+  individual detail sections in sequence.
 - Make each collapsed row show:
   - Exercise order.
   - Exercise name.
@@ -98,6 +100,8 @@ The implementation should introduce a small internal component system and design
 - Allow the video embed to sit behind a labeled disclosure if that materially reduces scroll fatigue.
 - Keep set checkboxes as comfortable tap rows without persisting completion.
 - Keep free-text weight input.
+- Show the complete latest saved-weight record in the expanded exercise details so
+  compact-row truncation never hides the retained context on touch devices.
 - Add an appropriate mobile keyboard hint such as `inputMode="decimal"` without restricting free-text values.
 - Keep Save as a clear icon-and-text action.
 - Preserve dirty-input tracking so service-worker updates cannot discard entered weight text.
@@ -181,6 +185,8 @@ Offline regression coverage must continue proving that the app shell, workout ro
 - Primary navigation and weight-entry controls meet a minimum `44px` touch-target size.
 - The top header is compact and route-specific.
 - Collapsed exercise rows show exercise name, working-set/rep summary, and latest saved weight when available.
+- Expanded exercise details show the complete latest saved-weight record with wrapping text.
+- Expanded exercise details collapse as one smooth region.
 - Exercise expansion still exposes programming details, notes, substitutions, video, set checkboxes, and weight entry.
 - Free-text weight entry still works with the existing persisted record shape.
 - Dirty input still defers PWA update reloads.
@@ -202,6 +208,8 @@ Offline regression coverage must continue proving that the app shell, workout ro
 - Playwright: a collapsed exercise row exposes exercise name and programming summary.
 - Playwright: expanding an exercise exposes free-text weight input and Save.
 - Playwright: saving weight updates the latest-weight indicator and History.
+- Playwright: expanding an exercise exposes the complete wrapped latest saved-weight record.
+- Playwright: exercise details use a single grid-row collapse transition without a synthetic maximum height.
 - Playwright: long exercise content does not create horizontal overflow at iPhone viewport width.
 - Visual QA screenshots: home workout collapsed, workout expanded, Directory, and History on mobile Chromium.
 - Visual QA screenshots: workout route on a desktop viewport.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hiit-web-app",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hiit-web-app",
-      "version": "4.0.0",
+      "version": "4.0.1",
       "dependencies": {
         "lucide-react": "^1.17.0",
         "react": "^19.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hiit-web-app",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "private": true,
   "description": "HIIT Workout Web App",
   "engines": {

--- a/src/components/history.tsx
+++ b/src/components/history.tsx
@@ -115,35 +115,40 @@ export function HistoryPage({ exercises }: { exercises: ExerciseMetadata[] }) {
                   id={`collapse-${id}`}
                   className={`accordion-content ${isOpen ? "open" : ""}`}
                 >
-                  <div className="accordion-body">
-                    {entries
-                      .slice()
-                      .reverse()
-                      .map((weight, index) => (
-                        <div
-                          className={`weight-entry ${index === 0 ? "latest" : ""}`}
-                          key={`${weight.id}-${String(weight.date)}-${index}`}
-                        >
-                          <div className="weight-entry__value">
-                            <span className="weight-number">
-                              {weight.weight}
-                            </span>
-                            {index === 0 ? (
-                              <span className="latest-badge">Latest</span>
-                            ) : null}
+                  <div className="accordion-content__inner">
+                    <div className="accordion-body">
+                      {entries
+                        .slice()
+                        .reverse()
+                        .map((weight, index) => (
+                          <div
+                            className={`weight-entry ${index === 0 ? "latest" : ""}`}
+                            key={`${weight.id}-${String(weight.date)}-${index}`}
+                          >
+                            <div className="weight-entry__value">
+                              <span className="weight-number">
+                                {weight.weight}
+                              </span>
+                              {index === 0 ? (
+                                <span className="latest-badge">Latest</span>
+                              ) : null}
+                            </div>
+                            <div className="weight-date">
+                              {new Date(weight.date).toLocaleDateString(
+                                "en-US",
+                                {
+                                  weekday: "short",
+                                  month: "short",
+                                  day: "numeric",
+                                  year: "numeric",
+                                  hour: "numeric",
+                                  minute: "2-digit",
+                                },
+                              )}
+                            </div>
                           </div>
-                          <div className="weight-date">
-                            {new Date(weight.date).toLocaleDateString("en-US", {
-                              weekday: "short",
-                              month: "short",
-                              day: "numeric",
-                              year: "numeric",
-                              hour: "numeric",
-                              minute: "2-digit",
-                            })}
-                          </div>
-                        </div>
-                      ))}
+                        ))}
+                    </div>
                   </div>
                 </div>
               </section>

--- a/src/components/workout.tsx
+++ b/src/components/workout.tsx
@@ -35,7 +35,7 @@ function showSavedToast() {
   }).showToast();
 }
 
-function LastWeight({ exerciseId }: { exerciseId: string }) {
+function useLastWeight(exerciseId: string) {
   const [weight, setWeight] = useState("");
   const requestSequence = useRef(0);
 
@@ -60,11 +60,21 @@ function LastWeight({ exerciseId }: { exerciseId: string }) {
     };
   }, [exerciseId]);
 
+  return weight;
+}
+
+function LastWeight({
+  variant = "compact",
+  weight,
+}: {
+  variant?: "compact" | "full";
+  weight: string;
+}) {
   const hasWeight = weight !== "";
 
   return (
     <span
-      className={`weight-badge ${hasWeight ? "" : "empty"}`}
+      className={`weight-badge weight-badge--${variant} ${hasWeight ? "" : "empty"}`}
       title={hasWeight ? `Last logged weight: ${weight}` : "No previous weight"}
     >
       {hasWeight ? (
@@ -97,9 +107,11 @@ function Metric({
 function WeightLogger({
   exercise,
   exerciseInstanceId,
+  latestWeight,
 }: {
   exercise: ExerciseProgramming;
   exerciseInstanceId: string;
+  latestWeight: string;
 }) {
   const [weight, setWeight] = useState("");
   const weightInputId = `weight-${exerciseInstanceId}`;
@@ -132,6 +144,12 @@ function WeightLogger({
         <p className="section-heading__eyebrow">Training log</p>
         <h3 id={`log-weight-${exerciseInstanceId}`}>Log weight</h3>
       </div>
+      {latestWeight ? (
+        <div className="weight-logger__latest">
+          <p className="detail-section__label">Last logged weight</p>
+          <LastWeight variant="full" weight={latestWeight} />
+        </div>
+      ) : null}
       <div className="weight-logger__controls">
         <input
           type="text"
@@ -158,10 +176,12 @@ function ExerciseDetails({
   exercise,
   exerciseDetails,
   exerciseInstanceId,
+  latestWeight,
 }: {
   exercise: ExerciseProgramming;
   exerciseDetails?: ExerciseMetadata;
   exerciseInstanceId: string;
+  latestWeight: string;
 }) {
   const { videoId, timestamp } = extractYouTubeVideoId(
     exerciseDetails?.link || "",
@@ -247,6 +267,7 @@ function ExerciseDetails({
       <WeightLogger
         exercise={exercise}
         exerciseInstanceId={exerciseInstanceId}
+        latestWeight={latestWeight}
       />
     </div>
   );
@@ -267,6 +288,7 @@ function ExerciseCard({
   const exerciseInstanceId = `${instanceId}-${exercise.id}-${index}`;
   const exerciseName =
     exerciseDetails?.name || exercise.name || "Unnamed exercise";
+  const latestWeight = useLastWeight(exercise.id);
 
   return (
     <section
@@ -290,7 +312,7 @@ function ExerciseCard({
           </span>
         </span>
         <span className="exercise-card__status">
-          <LastWeight exerciseId={exercise.id} />
+          <LastWeight weight={latestWeight} />
           <ChevronDown
             className="exercise-card__chevron"
             size={18}
@@ -304,11 +326,14 @@ function ExerciseCard({
         id={`content-${exerciseInstanceId}`}
         className={`accordion-content ${isOpen ? "open" : ""}`}
       >
-        <ExerciseDetails
-          exercise={exercise}
-          exerciseDetails={exerciseDetails}
-          exerciseInstanceId={exerciseInstanceId}
-        />
+        <div className="accordion-content__inner">
+          <ExerciseDetails
+            exercise={exercise}
+            exerciseDetails={exerciseDetails}
+            exerciseInstanceId={exerciseInstanceId}
+            latestWeight={latestWeight}
+          />
+        </div>
       </div>
     </section>
   );

--- a/src/styles.css
+++ b/src/styles.css
@@ -330,7 +330,7 @@ button {
   width: 100%;
   min-height: 72px;
   align-items: center;
-  gap: 10px;
+  gap: 7px;
   border: 0;
   background: transparent;
   color: var(--app-text);
@@ -390,17 +390,18 @@ button {
 
 .accordion-content {
   display: grid;
-  max-height: 0;
   overflow: hidden;
   grid-template-rows: 0fr;
-  transition:
-    grid-template-rows 180ms ease,
-    max-height 180ms ease;
+  transition: grid-template-rows 180ms ease;
 }
 
 .accordion-content.open {
-  max-height: 4000px;
   grid-template-rows: 1fr;
+}
+
+.accordion-content__inner {
+  min-height: 0;
+  overflow: hidden;
 }
 
 .exercise-card__details {
@@ -568,6 +569,11 @@ button {
   padding-top: 14px;
 }
 
+.weight-logger__latest {
+  display: grid;
+  gap: 5px;
+}
+
 .weight-logger__controls {
   display: grid;
   gap: 8px;
@@ -629,13 +635,22 @@ input::placeholder {
 
 .weight-badge {
   display: inline-flex;
-  max-width: 118px;
   min-width: 0;
   align-items: center;
   gap: 4px;
   color: var(--app-primary);
   font-size: 0.68rem;
   font-weight: 750;
+}
+
+.weight-badge--compact {
+  max-width: min(156px, 40vw);
+}
+
+.weight-badge--full {
+  max-width: 100%;
+  align-items: flex-start;
+  line-height: 1.45;
 }
 
 .weight-badge.empty {
@@ -650,6 +665,13 @@ input::placeholder {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.weight-badge--full .weight-value {
+  overflow: visible;
+  overflow-wrap: anywhere;
+  text-overflow: clip;
+  white-space: normal;
 }
 
 .directory-list {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "4.0.0";
+export const APP_VERSION = "4.0.1";
 export const DB_NAME = "hiit-app-db";
 export const WEIGHT_STORE = "Weights";
 export const PROD_HOSTNAME = "yourfriendfitz.github.io";

--- a/tests/e2e/current-app.spec.js
+++ b/tests/e2e/current-app.spec.js
@@ -104,7 +104,7 @@ test("loads the current workout on app launch", async ({ page }) => {
     page.getByRole("heading", { name: "Upper (Strength Focus)", level: 1 }),
   ).toBeVisible();
   await expect(page.locator(".exercise-card button").first()).toBeVisible();
-  await expect(page.locator("#versionIndicator")).toHaveText("v4.0.0");
+  await expect(page.locator("#versionIndicator")).toHaveText("v4.0.1");
 });
 
 test("adds and removes one recent missed workout from home", async ({
@@ -168,9 +168,9 @@ test("stores a missed-workout weight with its authored exercise id", async ({
   await firstExercise.locator('input[id^="weight-"]').fill("Added 155");
   await firstExercise.getByRole("button", { name: "Save" }).click();
 
-  await expect(firstExercise.locator(".weight-badge")).toContainText(
-    "Added 155",
-  );
+  await expect(
+    firstExercise.locator(".exercise-card__status .weight-badge"),
+  ).toContainText("Added 155");
   await expect
     .poll(() => getLastWeightRecord(page).then((record) => record?.id))
     .toBe(exerciseId);
@@ -219,6 +219,34 @@ test("renders one-handed navigation and scannable workout summaries", async ({
       () => document.documentElement.scrollWidth <= window.innerWidth,
     ),
   ).toBe(true);
+});
+
+test("collapses expanded exercise details as one grid transition", async ({
+  page,
+}) => {
+  await page.goto("/#/workout?week=0&day=0");
+
+  const firstExercise = page.locator(".exercise-card").first();
+  const accordion = firstExercise.locator(".accordion-content");
+  await firstExercise.locator("button").first().click();
+  await expect(accordion).toHaveClass(/open/);
+
+  await firstExercise.locator("button").first().click();
+
+  expect(
+    await accordion.evaluate((element) => {
+      const styles = window.getComputedStyle(element);
+      return {
+        maxHeight: styles.maxHeight,
+        transitionProperty: styles.transitionProperty,
+      };
+    }),
+  ).toEqual({
+    maxHeight: "none",
+    transitionProperty: "grid-template-rows",
+  });
+
+  await expect(accordion).toHaveCSS("grid-template-rows", "0px");
 });
 
 test("uses bottom navigation for directory, history, and home", async ({
@@ -329,9 +357,23 @@ test("saves a free-text weight and shows it in history", async ({ page }) => {
   await firstExercise.locator('input[id^="weight-"]').fill("Test 135");
   await firstExercise.getByRole("button", { name: "Save" }).click();
 
-  await expect(firstExercise.locator(".weight-badge")).toContainText(
-    "Test 135",
+  await expect(
+    firstExercise.locator(".exercise-card__status .weight-badge"),
+  ).toContainText("Test 135");
+
+  const fullLatestWeight = firstExercise.locator(".weight-badge--full");
+  await expect(fullLatestWeight).toContainText(
+    "Test 135 [Sets: 2, Reps: 6, Early RPE: ~6-7, Last RPE: ~7-8]",
   );
+  await expect(fullLatestWeight.locator(".weight-value")).toHaveCSS(
+    "white-space",
+    "normal",
+  );
+  expect(
+    await fullLatestWeight.evaluate(
+      (element) => element.scrollWidth <= element.clientWidth,
+    ),
+  ).toBe(true);
 
   await expect
     .poll(async () => {
@@ -407,9 +449,9 @@ test("reads seeded history and filters it by exercise name", async ({
 
   const firstExercise = page.locator(".exercise-card").first();
   await firstExercise.locator("button").first().click();
-  await expect(firstExercise.locator(".weight-badge")).toContainText(
-    "Legacy 105",
-  );
+  await expect(
+    firstExercise.locator(".exercise-card__status .weight-badge"),
+  ).toContainText("Legacy 105");
 
   await page.goto("/#/history");
 

--- a/tests/pwa/offline.spec.js
+++ b/tests/pwa/offline.spec.js
@@ -57,9 +57,9 @@ test("loads core routes and saves a weight offline after the first visit", async
   await addedExercise.locator("button").first().click();
   await addedExercise.locator('input[id^="weight-"]').fill("Offline added 125");
   await addedExercise.getByRole("button", { name: "Save" }).click();
-  await expect(addedExercise.locator(".weight-badge")).toContainText(
-    "Offline added 125",
-  );
+  await expect(
+    addedExercise.locator(".exercise-card__status .weight-badge"),
+  ).toContainText("Offline added 125");
 
   await page.goto("/#/directory");
   await expect(
@@ -71,9 +71,9 @@ test("loads core routes and saves a weight offline after the first visit", async
   await firstExercise.locator("button").first().click();
   await firstExercise.locator('input[id^="weight-"]').fill("Offline 145");
   await firstExercise.getByRole("button", { name: "Save" }).click();
-  await expect(firstExercise.locator(".weight-badge")).toContainText(
-    "Offline 145",
-  );
+  await expect(
+    firstExercise.locator(".exercise-card__status .weight-badge"),
+  ).toContainText("Offline 145");
 
   await page.goto("/#/history");
   await expect(page.getByText(/Offline 145/)).toBeVisible();


### PR DESCRIPTION
## Summary
- widen the compact saved-weight badge and expose the complete retained record inside expanded workout details
- replace synthetic max-height accordion clipping with a single smooth grid-row collapse for workout and History accordions
- align app metadata and release documentation to v4.0.1

## Compatibility
- IndexedDB remains `hiit-app-db` version `1` with the `Weights` store and `{ id, weight, date }` records
- legacy `/service-worker.js` migration bridge and generated `/sw.js` worker remain unchanged

## Verification
- `docker run --rm hiit-web-app-v4.0.1-candidate`
- `docker run --rm hiit-web-app-v4.0.1-candidate npm run build:pages`
- `docker run --rm -v "$PWD:/repo" -w /repo rhysd/actionlint:1.7.12`
- `git diff --check`
- served-app `414x896` probe confirmed monotonic accordion collapse from `666px` to `0px` over `180ms`

## Release Flow
After review approval: merge into `main`, verify the Pages deployment, then publish the annotated `v4.0.1` tag and GitHub Release from deployed `main`.