### PR TITLE
4.0.2 Restore free-form weight entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,8 +165,8 @@ Confirm the `github-pages` environment deployment succeeds after each reviewed `
 
 Use the [release checklist](docs/releases/RELEASE-CHECKLIST.md) for the final refactor cutover. The [installed PWA migration runbook](docs/releases/PWA-MIGRATION.md) covers existing `v3.0.4` installs. The [rollback runbook](docs/releases/ROLLBACK.md) records the protected pre-refactor production baseline and recovery steps.
 
-- Current public release: `v4.0.0`.
-- Prepare the saved-weight readability patch as [`v4.0.1`](docs/releases/v4.0.1.md).
+- Current public release: [`v4.0.1`](docs/releases/v4.0.1.md).
+- Prepare the free-form weight-entry patch as [`v4.0.2`](docs/releases/v4.0.2.md).
 - Include user-visible changes, migration notes, and known issues.
 - Keep the legacy PWA migration bridge deployed until a later owner-approved cleanup.
 - Verify install and update behavior manually in iPhone Safari before publishing a release.

--- a/docs/releases/v4.0.1.md
+++ b/docs/releases/v4.0.1.md
@@ -1,6 +1,6 @@
 # v4.0.1 Release Notes
 
-Status: Release candidate
+Status: Released
 
 ## Summary
 
@@ -29,20 +29,18 @@ No storage or PWA migration changes are included:
 
 ## Verification
 
-Before publication:
-
-- Run the clean Docker lint, formatting, typecheck, unit, production build,
-  mobile Chromium/WebKit, and offline PWA suites.
-- Verify the GitHub Pages repository-path artifact and GitHub Actions workflow.
-- Confirm a long saved-weight value remains compact in the collapsed row and is
-  fully readable after expanding the exercise.
-- Confirm the expanded value wraps without horizontal overflow on a phone
-  viewport.
-- Confirm an expanded exercise collapses smoothly without clipping its detail
-  sections one by one.
-- Review the Docker production preview at `http://localhost:8080`.
-- Merge the reviewed pull request into `main`, confirm the Pages deployment, then
-  publish the annotated `v4.0.1` tag and GitHub Release from deployed `main`.
+- Clean Docker lint, formatting, typecheck, unit, production build, mobile
+  Chromium/WebKit, and offline PWA suites passed before merge.
+- GitHub Actions workflow `26831648896` passed checks, built the Pages artifact,
+  and deployed from `main`.
+- Production smoke confirmed footer `v4.0.1`, complete wrapping saved-weight
+  context, no horizontal overflow at `414px`, and smooth accordion collapse.
+- Production `/service-worker.js`, `/sw.js`, and `/manifest.webmanifest`
+  returned `200`.
+- Annotated tag `v4.0.1` targets deployed `main` commit
+  `7b8b94d33de1f1b02de5c38b214b45304ce18d03`.
+- GitHub Release `v4.0.1` was published as public, non-draft, and
+  non-prerelease.
 
 ## Rollback
 

--- a/docs/releases/v4.0.2.md
+++ b/docs/releases/v4.0.2.md
@@ -1,0 +1,46 @@
+# v4.0.2 Release Notes
+
+Status: Release candidate
+
+## Summary
+
+`v4.0.2` restores fully free-form saved-weight entry on mobile keyboards. The
+weight field accepts the same kind of training notes users relied on before the
+`v4.0.1` patch, including punctuation and symbols such as semicolons and
+asterisks.
+
+## User-Visible Changes
+
+- Change the workout weight-entry keyboard hint from decimal to text so mobile
+  users can enter notes such as `40s; 9 for 95 9 RPE*`.
+- Keep saved values as free text with appended programming context.
+- Preserve History and Last Weight display behavior for long free-form entries.
+
+## Data And PWA Compatibility
+
+No storage or PWA migration changes are included:
+
+- Database: `hiit-app-db`
+- Database version: `1`
+- Store: `Weights`
+- Record shape: `{ id, weight, date }`
+- Legacy PWA bridge: retained at `/service-worker.js`
+- Generated Workbox worker: retained at `/sw.js`
+
+## Verification
+
+Before publication:
+
+- Run the clean Docker lint, formatting, typecheck, unit, production build,
+  mobile Chromium/WebKit, and offline PWA suites.
+- Confirm the weight-entry input exposes a text keyboard hint.
+- Confirm a free-form value like `40s; 9 for 95 9 RPE*` saves, appears in Last
+  Weight, and appears in History.
+- Confirm offline PWA weight save still supports punctuation and symbols.
+- Merge the reviewed pull request into `main`, confirm the Pages deployment, then
+  publish the annotated `v4.0.2` tag and GitHub Release from deployed `main`.
+
+## Rollback
+
+Follow [`ROLLBACK.md`](./ROLLBACK.md). This patch does not require a data
+migration.

--- a/docs/specs/0005-mobile-ui-system.md
+++ b/docs/specs/0005-mobile-ui-system.md
@@ -102,7 +102,8 @@ The implementation should introduce a small internal component system and design
 - Keep free-text weight input.
 - Show the complete latest saved-weight record in the expanded exercise details so
   compact-row truncation never hides the retained context on touch devices.
-- Add an appropriate mobile keyboard hint such as `inputMode="decimal"` without restricting free-text values.
+- Add an appropriate mobile keyboard hint that preserves free-form weight text,
+  punctuation, and symbols.
 - Keep Save as a clear icon-and-text action.
 - Preserve dirty-input tracking so service-worker updates cannot discard entered weight text.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hiit-web-app",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hiit-web-app",
-      "version": "4.0.1",
+      "version": "4.0.2",
       "dependencies": {
         "lucide-react": "^1.17.0",
         "react": "^19.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hiit-web-app",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "private": true,
   "description": "HIIT Workout Web App",
   "engines": {

--- a/src/components/workout.tsx
+++ b/src/components/workout.tsx
@@ -153,9 +153,9 @@ function WeightLogger({
       <div className="weight-logger__controls">
         <input
           type="text"
-          inputMode="decimal"
+          inputMode="text"
           id={weightInputId}
-          placeholder="Enter weight, e.g. 135 lbs"
+          placeholder="Enter weight or notes, e.g. 40s; RPE 9*"
           value={weight}
           onChange={(event) => {
             const nextWeight = event.target.value;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "4.0.1";
+export const APP_VERSION = "4.0.2";
 export const DB_NAME = "hiit-app-db";
 export const WEIGHT_STORE = "Weights";
 export const PROD_HOSTNAME = "yourfriendfitz.github.io";

--- a/tests/e2e/current-app.spec.js
+++ b/tests/e2e/current-app.spec.js
@@ -104,7 +104,7 @@ test("loads the current workout on app launch", async ({ page }) => {
     page.getByRole("heading", { name: "Upper (Strength Focus)", level: 1 }),
   ).toBeVisible();
   await expect(page.locator(".exercise-card button").first()).toBeVisible();
-  await expect(page.locator("#versionIndicator")).toHaveText("v4.0.1");
+  await expect(page.locator("#versionIndicator")).toHaveText("v4.0.2");
 });
 
 test("adds and removes one recent missed workout from home", async ({
@@ -210,7 +210,7 @@ test("renders one-handed navigation and scannable workout summaries", async ({
   await firstExercise.locator("button").first().click();
   const weightInput = firstExercise.locator('input[id^="weight-"]');
   const saveButton = firstExercise.getByRole("button", { name: "Save" });
-  await expect(weightInput).toHaveAttribute("inputmode", "decimal");
+  await expect(weightInput).toHaveAttribute("inputmode", "text");
   await expect(saveButton).toBeVisible();
   expect((await saveButton.boundingBox())?.height).toBeGreaterThanOrEqual(44);
 
@@ -352,18 +352,19 @@ test("uses immediate directory positioning when reduced motion is requested", as
 test("saves a free-text weight and shows it in history", async ({ page }) => {
   await page.goto("/#/workout?week=0&day=0");
 
+  const freeTextWeight = "40s; 9 for 95 9 RPE*";
   const firstExercise = page.locator(".exercise-card").first();
   await firstExercise.locator("button").first().click();
-  await firstExercise.locator('input[id^="weight-"]').fill("Test 135");
+  await firstExercise.locator('input[id^="weight-"]').fill(freeTextWeight);
   await firstExercise.getByRole("button", { name: "Save" }).click();
 
   await expect(
     firstExercise.locator(".exercise-card__status .weight-badge"),
-  ).toContainText("Test 135");
+  ).toContainText(freeTextWeight);
 
   const fullLatestWeight = firstExercise.locator(".weight-badge--full");
   await expect(fullLatestWeight).toContainText(
-    "Test 135 [Sets: 2, Reps: 6, Early RPE: ~6-7, Last RPE: ~7-8]",
+    `${freeTextWeight} [Sets: 2, Reps: 6, Early RPE: ~6-7, Last RPE: ~7-8]`,
   );
   await expect(fullLatestWeight.locator(".weight-value")).toHaveCSS(
     "white-space",
@@ -392,7 +393,7 @@ test("saves a free-text weight and shows it in history", async ({ page }) => {
   await page.goto("/#/history");
 
   await expect(page.getByPlaceholder("Search exercises...")).toBeVisible();
-  await expect(page.getByText(/Test 135/)).toBeVisible();
+  await expect(page.getByText(/40s; 9 for 95 9 RPE\*/)).toBeVisible();
 });
 
 test("stores stable context when optional RPE fields are absent", async ({

--- a/tests/pwa/offline.spec.js
+++ b/tests/pwa/offline.spec.js
@@ -69,14 +69,16 @@ test("loads core routes and saves a weight offline after the first visit", async
   await page.goto("/#/workout?week=0&day=0");
   const firstExercise = page.locator(".exercise-card").first();
   await firstExercise.locator("button").first().click();
-  await firstExercise.locator('input[id^="weight-"]').fill("Offline 145");
+  await firstExercise
+    .locator('input[id^="weight-"]')
+    .fill("Offline 145; 8 RPE*");
   await firstExercise.getByRole("button", { name: "Save" }).click();
   await expect(
     firstExercise.locator(".exercise-card__status .weight-badge"),
-  ).toContainText("Offline 145");
+  ).toContainText("Offline 145; 8 RPE*");
 
   await page.goto("/#/history");
-  await expect(page.getByText(/Offline 145/)).toBeVisible();
+  await expect(page.getByText(/Offline 145; 8 RPE\*/)).toBeVisible();
   await expect(page.getByText(/Offline added 125/)).toBeVisible();
 });
 

--- a/tests/unit/storage.test.ts
+++ b/tests/unit/storage.test.ts
@@ -141,13 +141,13 @@ describe("IndexedDBWeightStorage", () => {
   it("writes exactly the legacy-compatible record shape", async () => {
     const storage = createStorage();
 
-    await storage.saveWeight("curl", "Test 35");
+    await storage.saveWeight("curl", "40s; 9 for 95 9 RPE*");
 
     const [record] = await storage.listWeights();
     expect(Object.keys(record).sort()).toEqual(["date", "id", "weight"]);
     expect(record).toEqual({
       id: "curl",
-      weight: "Test 35",
+      weight: "40s; 9 for 95 9 RPE*",
       date: expect.any(Date),
     });
   });


### PR DESCRIPTION
## Summary

- restore the workout weight input to use a text keyboard hint so mobile users can enter punctuation and symbols
- bump the patch candidate to v4.0.2 and add release notes
- add online, offline, and storage regressions for free-form values like `40s; 9 for 95 9 RPE*`

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run test` (26 passed)
- `npm run build`
- `npm run build:pages`
- `npm run test:e2e` (26 passed)
- `npm run test:pwa` (2 passed)
- `git diff --check`
- Docker production preview running at `http://localhost:8080`