### PR TITLE
Add v4.1.1 history backup and restore

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Use the [release checklist](docs/releases/RELEASE-CHECKLIST.md) for the final re
 - Current public release: [`v4.0.1`](docs/releases/v4.0.1.md).
 - Prepare the free-form weight-entry patch as [`v4.0.2`](docs/releases/v4.0.2.md).
 - Prepare the cycle-aware schedule and icon refresh as [`v4.1.0`](docs/releases/v4.1.0.md).
+- Prepare the History backup and restore patch as [`v4.1.1`](docs/releases/v4.1.1.md).
 - Include user-visible changes, migration notes, and known issues.
 - Keep the legacy PWA migration bridge deployed until a later owner-approved cleanup.
 - Verify install and update behavior manually in iPhone Safari before publishing a release.

--- a/docs/releases/v4.1.1.md
+++ b/docs/releases/v4.1.1.md
@@ -1,0 +1,60 @@
+# v4.1.1 Release Notes
+
+Status: Release candidate
+
+## Summary
+
+`v4.1.1` adds a local History backup and restore path for iPhone PWA users who
+installed a second copy of the app to pick up the refreshed icon. The older PWA
+install can export saved weight history as JSON, and the newer install can
+import that backup into its own local IndexedDB store.
+
+## User-Visible Changes
+
+- Add Export and Import controls to History.
+- Export saved weights to a local JSON backup file.
+- Import a valid backup file into the current install.
+- Skip exact duplicates when the same backup is imported more than once.
+- Show concise success and error feedback for backup actions.
+
+## Data And PWA Compatibility
+
+No IndexedDB schema migration is included:
+
+- Database: `hiit-app-db`
+- Database version: `1`
+- Store: `Weights`
+- Record shape: `{ id, weight, date }`
+- Legacy PWA bridge: retained at `/service-worker.js`
+- Generated Workbox worker: retained at `/sw.js`
+
+Imported records use parseable ISO date strings and preserve the same record
+shape used by existing History and Last Weight reads.
+
+## iPhone Transfer Workflow
+
+For the icon-refresh case:
+
+1. Keep the old PWA installed.
+2. Open the old PWA and export History.
+3. Open the new PWA with the updated icon.
+4. Import the backup file.
+5. Reload and confirm History appears in the new PWA.
+6. Remove the old PWA only after the new one has the expected history.
+
+## Verification
+
+Before publication:
+
+- Run clean Docker lint, formatting, typecheck, unit, production build,
+  Chromium/WebKit E2E, and offline PWA suites.
+- Confirm export creates a JSON file with all saved records.
+- Confirm import preserves existing records and skips duplicates.
+- Confirm malformed backup files do not write records.
+- Confirm offline export/import works from the installed PWA preview.
+- Manually verify the old-PWA to new-PWA transfer on iPhone.
+
+## Rollback
+
+Follow [`ROLLBACK.md`](./ROLLBACK.md). This patch does not require a database
+migration or cleanup.

--- a/docs/rfcs/0002-ios-pwa-history-backup-restore.md
+++ b/docs/rfcs/0002-ios-pwa-history-backup-restore.md
@@ -1,10 +1,12 @@
 # RFC 0002: iOS PWA History Backup And Restore
 
-Status: Draft
+Status: Accepted
 
 Owner: Fitz
 
 Created: 2026-06-26T15:25:29-05:00
+
+Accepted: 2026-06-26T20:32:30-05:00
 
 Target release: `v4.1.1`
 
@@ -249,10 +251,6 @@ and avoid repeat imports until a fixed patch is deployed.
 
 ## Open Questions
 
-- Should import live only on History, or should empty History show a stronger
-  import-first call to action?
-- Should export include `APP_VERSION` as informational metadata?
-- Should import show a preview/confirmation step before writing records, or is a
-  direct validated merge acceptable for `v4.1.1`?
-- Should the backup file include a checksum for accidental edit detection, or is
-  strict JSON validation enough for the initial patch?
+- None known. The accepted `v4.1.1` direction is History-only controls, no
+  `APP_VERSION` metadata, direct validated merge, and strict JSON validation
+  without a checksum.

--- a/docs/rfcs/0002-ios-pwa-history-backup-restore.md
+++ b/docs/rfcs/0002-ios-pwa-history-backup-restore.md
@@ -1,0 +1,258 @@
+# RFC 0002: iOS PWA History Backup And Restore
+
+Status: Draft
+
+Owner: Fitz
+
+Created: 2026-06-26T15:25:29-05:00
+
+Target release: `v4.1.1`
+
+## Summary
+
+`v4.1.0` refreshed the app icon set. A new iPhone Home Screen install now shows
+the updated icon, but it does not automatically share the saved weight history
+from the older installed PWA. The older install still contains the real
+device-local IndexedDB history, while the new install starts with an empty
+`hiit-app-db` database.
+
+Add an explicit, user-controlled backup and restore path for saved weight
+history. The immediate `v4.1.1` goal is to let users export history from the old
+PWA and import it into a new install without cloud sync, accounts, or an
+IndexedDB schema migration.
+
+## Problem Statement
+
+Saved weight history is intentionally local-only:
+
+- Database: `hiit-app-db`
+- Version: `1`
+- Store: `Weights`
+- Record shape: `{ id, weight, date }`
+
+That contract preserved existing records through the refactor and `v4.1.0`
+release, but it does not solve a separate iOS behavior: installing the same web
+app to the Home Screen again can create a separate app/storage container. In the
+observed case, the second install got the new icon but did not inherit the old
+install's IndexedDB records.
+
+Without export/import, the user must choose between:
+
+- Keeping the old icon install because it has history.
+- Using the new icon install and losing visible history.
+
+That is not acceptable for a workout tracker where local history is the primary
+user-owned data.
+
+## Goals
+
+- Preserve the old PWA install as the source of truth until the user verifies a
+  successful import elsewhere.
+- Add a safe History backup export that serializes all `Weights` records to a
+  portable JSON file.
+- Add a restore/import path that reads a valid backup JSON file and writes
+  records into the current install's `Weights` store.
+- Keep the app backend-free, account-free, and offline-capable.
+- Keep the IndexedDB database name, version, store name, indexes, and record
+  shape unchanged.
+- Make import idempotent enough that accidentally importing the same backup
+  twice does not create obvious duplicate history entries.
+- Provide clear in-app feedback for export success, import success, invalid
+  files, empty backups, and partial failures.
+- Add automated tests for serialization, validation, deduplication, and import
+  persistence.
+- Document the manual iPhone transfer workflow.
+
+## Non-Goals
+
+- Do not add cloud sync.
+- Do not add accounts or authentication.
+- Do not add a backend.
+- Do not change workout programming or exercise metadata.
+- Do not migrate IndexedDB to version `2`.
+- Do not delete, replace, or clear existing local history during import by
+  default.
+- Do not attempt to force iOS to refresh an already-installed Home Screen icon.
+- Do not rely on Safari remote debugging as the normal user recovery path.
+
+## Proposed Direction
+
+Add backup and restore controls to the History route because that is where users
+already expect saved-weight management to live.
+
+Export should:
+
+- Read all records through the existing storage boundary.
+- Normalize each record to `{ id, weight, date }`.
+- Emit a JSON document with a small metadata wrapper, for example:
+
+  ```json
+  {
+    "app": "hiit-web-app",
+    "format": "weights-backup",
+    "formatVersion": 1,
+    "exportedAt": "2026-06-26T20:25:29.000Z",
+    "recordCount": 2,
+    "records": [
+      {
+        "id": "bench-press",
+        "weight": "185 x 5",
+        "date": "2026-06-25T18:30:00.000Z"
+      }
+    ]
+  }
+  ```
+
+- Trigger a local file download with a predictable name such as
+  `hiit-history-backup-YYYY-MM-DD.json`.
+- Avoid sending data over the network.
+
+Import should:
+
+- Accept only JSON files.
+- Validate the metadata wrapper and every record.
+- Require `id`, `weight`, and `date`.
+- Reject records with invalid dates or non-string values.
+- Deduplicate against existing records before writing. The initial dedupe key
+  should be exact `id`, exact `weight`, and normalized ISO `date`.
+- Merge valid non-duplicate records into the existing store.
+- Never clear existing records unless a future RFC explicitly adds a destructive
+  replace mode.
+- Show how many records were imported and how many were skipped as duplicates.
+
+## User Workflow
+
+Recommended recovery path for the current iPhone issue:
+
+1. Open the old PWA that still has History.
+2. Go to History and export a backup JSON file.
+3. Keep the old PWA installed.
+4. Open the new PWA with the updated icon.
+5. Go to History and import the backup JSON file.
+6. Confirm History shows the expected exercises and entries.
+7. Only after verification, remove the old Home Screen install if desired.
+
+## User Impact
+
+Users gain an escape hatch for local-only data. The feature makes icon-refresh
+reinstalls, device replacement, and manual backups safer without changing the
+app's privacy model.
+
+The History route will gain small backup/restore controls. Empty-history users
+should not see noise beyond a concise import option.
+
+## Architecture Impact
+
+`src/storage.ts` remains the only IndexedDB ownership boundary. It likely needs
+one narrow addition for bulk import, or a small wrapper module can compose the
+existing `listWeights()` and a new `saveWeightRecord()` helper.
+
+Preferred module split:
+
+- `src/storage.ts`: IndexedDB reads/writes and transaction safety.
+- `src/history-backup.ts`: JSON serialization, parsing, validation, and
+  deduplication.
+- `src/components/history.tsx`: backup/restore controls and user feedback.
+
+The backup format should be versioned independently from IndexedDB so future
+app versions can read `formatVersion: 1` without a database migration.
+
+## Data And Storage Impact
+
+No schema migration is planned.
+
+- Database remains `hiit-app-db`.
+- Version remains `1`.
+- Store remains `Weights`.
+- Record shape remains `{ id, weight, date }`.
+
+Import writes the same record shape already produced by normal weight entry.
+Existing records stay intact.
+
+## Offline And PWA Impact
+
+Backup and restore should work offline because both operations are local file
+and IndexedDB operations. The generated Workbox service worker and legacy
+`public/service-worker.js` bridge should not need changes.
+
+The feature should be manually verified inside installed iPhone PWAs because the
+original problem is specific to multiple Home Screen installs with separate
+history containers.
+
+## Security And Privacy
+
+Backups contain personal workout history. The app should treat the backup as a
+local user-owned file:
+
+- Do not upload backups.
+- Do not log backup contents.
+- Do not include unrelated browser or device metadata.
+- Keep the JSON human-readable so users can inspect it.
+- Make import validation strict enough that malformed files cannot corrupt local
+  history.
+
+## Files Likely Touched
+
+- `src/storage.ts`
+- `src/history-backup.ts`
+- `src/components/history.tsx`
+- `src/styles.css`
+- `tests/unit/storage.test.ts`
+- `tests/unit/history-backup.test.ts`
+- `tests/e2e/current-app.spec.js`
+- `tests/pwa/offline.spec.js`
+- `docs/releases/v4.1.1.md`
+- `docs/specs/0010-history-backup-restore.md`
+- `README.md`
+
+## Acceptance Criteria
+
+- A user can export all saved weight history from the old PWA as a JSON file.
+- A user can import that JSON file into a separate empty PWA install.
+- Imported records appear in History after import and after reload.
+- Importing the same backup twice skips duplicates rather than doubling entries.
+- Importing a malformed file shows an error and writes no records.
+- Importing an empty valid backup shows a clear no-records message and writes no
+  records.
+- Existing local records are preserved during import.
+- The IndexedDB database remains version `1` with the `Weights` store and
+  `{ id, weight, date }` records.
+- Export/import works while the app is service-worker controlled and offline.
+- Documentation tells users not to delete the old PWA until the new PWA shows
+  the imported History.
+
+## Test Plan
+
+- Unit test backup serialization with real `WeightRecord` inputs.
+- Unit test backup parsing and validation for valid, malformed, empty, and
+  wrong-app files.
+- Unit test deduplication using exact `id` + `weight` + normalized ISO `date`.
+- Unit test bulk import preserves existing records and writes only valid
+  non-duplicates.
+- E2E test exporting seeded history, importing into a cleared database, and
+  seeing History entries after reload.
+- PWA test export/import while service-worker controlled and offline.
+- Manual iPhone test with two Home Screen installs:
+  - Old icon install exports history.
+  - New icon install imports history.
+  - New icon install shows records after reload.
+  - Old install remains intact until user deletes it manually.
+
+## Rollback Plan
+
+If the feature misbehaves before release, revert the backup/restore UI and
+helper modules. Because the feature should not migrate IndexedDB or alter
+existing records destructively, rollback should not require data cleanup.
+
+If an import defect reaches production, advise users to keep the old PWA install
+and avoid repeat imports until a fixed patch is deployed.
+
+## Open Questions
+
+- Should import live only on History, or should empty History show a stronger
+  import-first call to action?
+- Should export include `APP_VERSION` as informational metadata?
+- Should import show a preview/confirmation step before writing records, or is a
+  direct validated merge acceptable for `v4.1.1`?
+- Should the backup file include a checksum for accidental edit detection, or is
+  strict JSON validation enough for the initial patch?

--- a/docs/specs/0010-history-backup-restore.md
+++ b/docs/specs/0010-history-backup-restore.md
@@ -1,0 +1,161 @@
+# Milestone 10 Spec: History Backup And Restore
+
+Status: Accepted
+
+Owner: Fitz
+
+Created: 2026-06-26T20:32:30-05:00
+
+Accepted: 2026-06-26T20:32:30-05:00
+
+Related RFC: [`RFC 0002`](../rfcs/0002-ios-pwa-history-backup-restore.md)
+
+Related ADRs:
+
+- [`ADR 0003`](../adr/0003-indexeddb-preservation.md)
+
+## Summary
+
+Add a local History backup and restore feature for `v4.1.1`. The immediate
+problem is an iPhone Home Screen re-install: the new install gets the refreshed
+icon, but its storage starts empty while the older installed PWA still owns the
+real IndexedDB history.
+
+The feature lets the old install export saved weights to a JSON file and lets
+the new install import that file into its own `Weights` store. It preserves the
+existing local-only model and does not change the IndexedDB schema.
+
+## Goals
+
+- Export all saved weight records from the History route.
+- Import a valid backup JSON file into an empty or existing install.
+- Preserve existing local records during import.
+- Skip exact duplicates on repeated import.
+- Keep the database `hiit-app-db` at version `1`.
+- Keep the object store `Weights` and record shape `{ id, weight, date }`.
+- Work offline after the app is installed and service-worker controlled.
+- Give concise success/error feedback in the app.
+- Document that users must keep the old PWA until the new one shows imported
+  history.
+
+## Non-Goals
+
+- Do not add cloud sync, accounts, or a backend.
+- Do not force iOS to update an existing Home Screen icon.
+- Do not delete or clear records during import.
+- Do not add a destructive replace mode.
+- Do not migrate IndexedDB to a new version.
+- Do not change workout data or exercise metadata.
+
+## Scope
+
+- Add backup serialization, validation, and deduplication helpers.
+- Add an IndexedDB bulk import method that writes the existing record shape.
+- Add Export and Import controls to the History route.
+- Add unit tests for backup format, parsing, validation, and duplicate handling.
+- Add storage tests for merge-only bulk import.
+- Add browser tests for export/import behavior.
+- Add release documentation for `v4.1.1`.
+
+## User Impact
+
+Users can move local History from an old iPhone PWA install to a new one with
+the updated icon. The old install remains the source of truth until the user
+confirms the new install has the imported records.
+
+History gains small Export and Import controls. Normal workout logging and
+History browsing remain unchanged.
+
+## Architecture Impact
+
+The storage boundary stays in `src/storage.ts`. A new helper module owns backup
+JSON concerns so UI and IndexedDB code do not duplicate validation logic.
+
+Expected module split:
+
+- `src/history-backup.ts`: backup format constants, serialization, parsing,
+  validation, filename generation, and deduplication.
+- `src/storage.ts`: existing IndexedDB adapter plus merge-only bulk import.
+- `src/components/history.tsx`: user controls and feedback.
+
+## Data And Storage Impact
+
+No schema migration is allowed.
+
+- Database: `hiit-app-db`
+- Version: `1`
+- Store: `Weights`
+- Record shape: `{ id, weight, date }`
+
+Imported records use normalized ISO date strings. Existing code already reads
+Date objects and parseable date strings, so this remains inside the established
+compatibility contract.
+
+## Offline And PWA Impact
+
+Export and import are local file and IndexedDB operations. They should work
+after the app shell is cached and the browser is offline.
+
+No service-worker strategy change is expected. The legacy
+`public/service-worker.js` migration bridge stays unchanged.
+
+## Files Touched
+
+- `README.md`
+- `docs/releases/v4.1.1.md`
+- `docs/rfcs/0002-ios-pwa-history-backup-restore.md`
+- `docs/specs/0010-history-backup-restore.md`
+- `package.json`
+- `package-lock.json`
+- `src/components/history.tsx`
+- `src/history-backup.ts`
+- `src/storage.ts`
+- `src/styles.css`
+- `src/types.ts`
+- `tests/e2e/current-app.spec.js`
+- `tests/pwa/offline.spec.js`
+- `tests/unit/history-backup.test.ts`
+- `tests/unit/storage.test.ts`
+
+## Acceptance Criteria
+
+- Export creates a JSON backup with metadata and all saved weight records.
+- Export never sends data over the network.
+- Import rejects malformed, wrong-format, or invalid-date files without writing
+  records.
+- Import merges valid records into the current `Weights` store.
+- Import preserves existing records.
+- Importing the same backup twice skips duplicates.
+- Imported records appear in History immediately and after reload.
+- Existing Last Weight behavior still reads imported records.
+- Offline export/import passes in the service-worker-controlled PWA test.
+- App version surfaces report `v4.1.1`.
+
+## Regression Tests
+
+- Unit tests cover serialization, filename generation, parsing, validation, and
+  duplicate planning.
+- Storage tests cover merge-only bulk import and the unchanged version-1
+  database contract.
+- E2E tests cover browser export, import into a cleared database, duplicate
+  import, and History display after reload.
+- PWA tests cover offline import/export after first controlled load.
+
+## Manual QA Checklist
+
+- Open the old iPhone PWA and export History.
+- Open the new iPhone PWA and import the backup.
+- Confirm the new install shows expected History after reload.
+- Confirm the old install still shows its original History.
+- Import the same backup again and confirm entries are not duplicated.
+- Try importing a non-backup JSON file and confirm no records are written.
+
+## Rollback Plan
+
+Revert the backup UI, helper module, storage bulk import, tests, and docs. No
+database cleanup should be required because the feature does not migrate schema
+or delete records.
+
+## Open Questions
+
+- None known.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hiit-web-app",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hiit-web-app",
-      "version": "4.1.0",
+      "version": "4.1.1",
       "dependencies": {
         "lucide-react": "^1.17.0",
         "react": "^19.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hiit-web-app",
-  "version": "4.1.0",
+  "version": "4.1.1",
   "private": true,
   "description": "HIIT Workout Web App",
   "engines": {

--- a/src/components/history.tsx
+++ b/src/components/history.tsx
@@ -1,13 +1,48 @@
-import { ChevronDown, Search, TrendingUp } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import {
+  ChevronDown,
+  Download,
+  Search,
+  TrendingUp,
+  Upload,
+} from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import Toastify from "toastify-js";
 
-import { getAllWeights } from "../storage";
+import {
+  createWeightHistoryBackup,
+  getWeightHistoryBackupFileName,
+  parseWeightHistoryBackup,
+  planWeightHistoryImport,
+  serializeWeightHistoryBackup,
+} from "../history-backup";
+import { getAllWeights, importWeights } from "../storage";
 import type { ExerciseMetadata, WeightRecord } from "../types";
+
+function showHistoryToast(text: string) {
+  Toastify({
+    text,
+    duration: 2500,
+    gravity: "bottom",
+    position: "center",
+    stopOnFocus: true,
+    className: "toastify",
+  }).showToast();
+}
+
+function describeRecordCount(count: number) {
+  return `${count} ${count === 1 ? "record" : "records"}`;
+}
 
 export function HistoryPage({ exercises }: { exercises: ExerciseMetadata[] }) {
   const [weights, setWeights] = useState<WeightRecord[]>([]);
   const [filter, setFilter] = useState("");
   const [openIds, setOpenIds] = useState<Set<string>>(() => new Set());
+  const [backupStatus, setBackupStatus] = useState<{
+    tone: "error" | "success";
+    text: string;
+  } | null>(null);
+  const [isImporting, setIsImporting] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     const update = () => {
@@ -61,8 +96,118 @@ export function HistoryPage({ exercises }: { exercises: ExerciseMetadata[] }) {
     });
   };
 
+  const exportHistory = async () => {
+    try {
+      const records = await getAllWeights();
+
+      if (records.length === 0) {
+        const text = "No history to export yet.";
+        setBackupStatus({ tone: "error", text });
+        showHistoryToast(text);
+        return;
+      }
+
+      const backup = createWeightHistoryBackup(records);
+      const blob = new Blob([serializeWeightHistoryBackup(backup)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = getWeightHistoryBackupFileName(backup.exportedAt);
+      document.body.append(link);
+      link.click();
+      link.remove();
+      window.setTimeout(() => URL.revokeObjectURL(url), 0);
+
+      const text = `Exported ${describeRecordCount(backup.recordCount)}.`;
+      setBackupStatus({ tone: "success", text });
+      showHistoryToast("History exported");
+    } catch (error) {
+      const text =
+        error instanceof Error ? error.message : "History export failed.";
+      setBackupStatus({ tone: "error", text });
+      showHistoryToast("History export failed");
+    }
+  };
+
+  const importHistory = async (file: File) => {
+    setIsImporting(true);
+
+    try {
+      const backup = parseWeightHistoryBackup(await file.text());
+      const plan = planWeightHistoryImport(
+        await getAllWeights(),
+        backup.records,
+      );
+      const importedCount = await importWeights(plan.recordsToImport);
+      const nextWeights = await getAllWeights();
+      setWeights(nextWeights);
+
+      const importedText = `Imported ${describeRecordCount(importedCount)}`;
+      const skippedText =
+        plan.skippedDuplicates > 0
+          ? `Skipped ${describeRecordCount(plan.skippedDuplicates)}.`
+          : "No duplicates skipped.";
+      const text = `${importedText}. ${skippedText}`;
+      setBackupStatus({ tone: "success", text });
+      showHistoryToast("History imported");
+    } catch (error) {
+      const text = `Import failed: ${
+        error instanceof Error ? error.message : "Unknown backup error."
+      }`;
+      setBackupStatus({ tone: "error", text });
+      showHistoryToast("History import failed");
+    } finally {
+      setIsImporting(false);
+    }
+  };
+
   return (
     <div className="history-page">
+      <div className="history-actions" aria-label="History backup actions">
+        <button
+          type="button"
+          className="secondary-action history-actions__button"
+          onClick={exportHistory}
+          disabled={weights.length === 0 || isImporting}
+        >
+          <Download size={18} strokeWidth={2.25} aria-hidden="true" />
+          <span>Export</span>
+        </button>
+        <button
+          type="button"
+          className="primary-action history-actions__button"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={isImporting}
+        >
+          <Upload size={18} strokeWidth={2.25} aria-hidden="true" />
+          <span>{isImporting ? "Importing" : "Import"}</span>
+        </button>
+        <input
+          ref={fileInputRef}
+          className="history-actions__file"
+          type="file"
+          accept="application/json,.json"
+          aria-label="Import history backup"
+          onChange={(event) => {
+            const file = event.target.files?.[0];
+            event.currentTarget.value = "";
+            if (file) {
+              void importHistory(file);
+            }
+          }}
+        />
+      </div>
+      {backupStatus ? (
+        <p
+          className={`history-actions__status history-actions__status--${backupStatus.tone}`}
+          role="status"
+        >
+          {backupStatus.text}
+        </p>
+      ) : null}
+
       <label className="search-container" htmlFor="searchBar">
         <Search className="search-icon" size={18} strokeWidth={2.25} />
         <input

--- a/src/components/history.tsx
+++ b/src/components/history.tsx
@@ -190,6 +190,7 @@ export function HistoryPage({ exercises }: { exercises: ExerciseMetadata[] }) {
           type="file"
           accept="application/json,.json"
           aria-label="Import history backup"
+          tabIndex={-1}
           onChange={(event) => {
             const file = event.target.files?.[0];
             event.currentTarget.value = "";

--- a/src/history-backup.ts
+++ b/src/history-backup.ts
@@ -1,0 +1,217 @@
+import type { WeightRecord } from "./types";
+
+export const WEIGHT_BACKUP_APP = "hiit-web-app";
+export const WEIGHT_BACKUP_FORMAT = "weights-backup";
+export const WEIGHT_BACKUP_FORMAT_VERSION = 1;
+
+export type BackupWeightRecord = {
+  id: string;
+  weight: string;
+  date: string;
+};
+
+export type WeightHistoryBackup = {
+  app: typeof WEIGHT_BACKUP_APP;
+  format: typeof WEIGHT_BACKUP_FORMAT;
+  formatVersion: typeof WEIGHT_BACKUP_FORMAT_VERSION;
+  exportedAt: string;
+  recordCount: number;
+  records: BackupWeightRecord[];
+};
+
+export type WeightHistoryImportPlan = {
+  recordsToImport: BackupWeightRecord[];
+  skippedDuplicates: number;
+};
+
+export class WeightHistoryBackupError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WeightHistoryBackupError";
+  }
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeDate(value: Date | string, label: string) {
+  const date = value instanceof Date ? value : new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    throw new WeightHistoryBackupError(`${label} has an invalid date.`);
+  }
+
+  return date.toISOString();
+}
+
+function assertString(value: unknown, label: string) {
+  if (typeof value !== "string" || value.trim() === "") {
+    throw new WeightHistoryBackupError(`${label} must be a non-empty string.`);
+  }
+
+  return value;
+}
+
+export function normalizeWeightRecord(
+  record: WeightRecord,
+  label = "Record",
+): BackupWeightRecord {
+  return {
+    id: assertString(record.id, `${label} id`),
+    weight: assertString(record.weight, `${label} weight`),
+    date: normalizeDate(record.date, `${label} date`),
+  };
+}
+
+function normalizeBackupRecord(
+  value: unknown,
+  index: number,
+): BackupWeightRecord {
+  if (!isObject(value)) {
+    throw new WeightHistoryBackupError(
+      `Record ${index + 1} must be an object.`,
+    );
+  }
+
+  return normalizeWeightRecord(
+    {
+      id: value.id,
+      weight: value.weight,
+      date: value.date,
+    } as WeightRecord,
+    `Record ${index + 1}`,
+  );
+}
+
+function compareRecords(first: BackupWeightRecord, second: BackupWeightRecord) {
+  const byDate = first.date.localeCompare(second.date);
+  if (byDate !== 0) {
+    return byDate;
+  }
+
+  const byId = first.id.localeCompare(second.id);
+  if (byId !== 0) {
+    return byId;
+  }
+
+  return first.weight.localeCompare(second.weight);
+}
+
+export function createWeightHistoryBackup(
+  records: WeightRecord[],
+  exportedAt: Date | string = new Date(),
+): WeightHistoryBackup {
+  const normalizedRecords = records.map((record, index) =>
+    normalizeWeightRecord(record, `Record ${index + 1}`),
+  );
+
+  normalizedRecords.sort(compareRecords);
+
+  return {
+    app: WEIGHT_BACKUP_APP,
+    format: WEIGHT_BACKUP_FORMAT,
+    formatVersion: WEIGHT_BACKUP_FORMAT_VERSION,
+    exportedAt: normalizeDate(exportedAt, "Export timestamp"),
+    recordCount: normalizedRecords.length,
+    records: normalizedRecords,
+  };
+}
+
+export function serializeWeightHistoryBackup(backup: WeightHistoryBackup) {
+  return `${JSON.stringify(backup, null, 2)}\n`;
+}
+
+export function getWeightHistoryBackupFileName(
+  exportedAt: Date | string = new Date(),
+) {
+  return `hiit-history-backup-${normalizeDate(exportedAt, "Export timestamp").slice(0, 10)}.json`;
+}
+
+export function parseWeightHistoryBackup(contents: string) {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(contents);
+  } catch {
+    throw new WeightHistoryBackupError("Backup file is not valid JSON.");
+  }
+
+  if (!isObject(parsed)) {
+    throw new WeightHistoryBackupError("Backup file must be a JSON object.");
+  }
+
+  if (parsed.app !== WEIGHT_BACKUP_APP) {
+    throw new WeightHistoryBackupError("Backup file is for a different app.");
+  }
+
+  if (parsed.format !== WEIGHT_BACKUP_FORMAT) {
+    throw new WeightHistoryBackupError(
+      "Backup file has an unsupported format.",
+    );
+  }
+
+  if (parsed.formatVersion !== WEIGHT_BACKUP_FORMAT_VERSION) {
+    throw new WeightHistoryBackupError(
+      "Backup file has an unsupported version.",
+    );
+  }
+
+  if (!Array.isArray(parsed.records)) {
+    throw new WeightHistoryBackupError("Backup file is missing records.");
+  }
+
+  if (
+    typeof parsed.recordCount !== "number" ||
+    parsed.recordCount !== parsed.records.length
+  ) {
+    throw new WeightHistoryBackupError("Backup file record count is invalid.");
+  }
+
+  return {
+    app: WEIGHT_BACKUP_APP,
+    format: WEIGHT_BACKUP_FORMAT,
+    formatVersion: WEIGHT_BACKUP_FORMAT_VERSION,
+    exportedAt: normalizeDate(
+      assertString(parsed.exportedAt, "Export timestamp"),
+      "Export timestamp",
+    ),
+    recordCount: parsed.records.length,
+    records: parsed.records.map(normalizeBackupRecord).sort(compareRecords),
+  } satisfies WeightHistoryBackup;
+}
+
+export function getWeightRecordKey(record: WeightRecord) {
+  const normalizedRecord = normalizeWeightRecord(record);
+  return `${normalizedRecord.id}\u0000${normalizedRecord.weight}\u0000${normalizedRecord.date}`;
+}
+
+export function planWeightHistoryImport(
+  existingRecords: WeightRecord[],
+  incomingRecords: WeightRecord[],
+): WeightHistoryImportPlan {
+  const seenKeys = new Set(existingRecords.map(getWeightRecordKey));
+  const recordsToImport: BackupWeightRecord[] = [];
+  let skippedDuplicates = 0;
+
+  incomingRecords.forEach((record, index) => {
+    const normalizedRecord = normalizeWeightRecord(
+      record,
+      `Record ${index + 1}`,
+    );
+    const key = getWeightRecordKey(normalizedRecord);
+
+    if (seenKeys.has(key)) {
+      skippedDuplicates += 1;
+      return;
+    }
+
+    seenKeys.add(key);
+    recordsToImport.push(normalizedRecord);
+  });
+
+  return {
+    recordsToImport,
+    skippedDuplicates,
+  };
+}

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -11,6 +11,7 @@ type StorageAdapterOptions = {
 export interface WeightStorage {
   open(): Promise<IDBDatabase>;
   getLatestWeight(id: string): Promise<string>;
+  importWeights(records: WeightRecord[]): Promise<number>;
   listWeights(): Promise<WeightRecord[]>;
   saveWeight(id: string, weight: string): Promise<void>;
   close(): void;
@@ -88,6 +89,36 @@ export class IndexedDBWeightStorage implements WeightStorage {
         reject(tx.error || new Error("Failed to store weight."));
       tx.onabort = () =>
         reject(tx.error || new Error("Weight transaction aborted."));
+    });
+  }
+
+  async importWeights(records: WeightRecord[]): Promise<number> {
+    if (records.length === 0) {
+      return 0;
+    }
+
+    const db = await this.open();
+    const tx = db.transaction(WEIGHT_STORE, "readwrite");
+    const store = tx.objectStore(WEIGHT_STORE);
+
+    records.forEach((record) => {
+      store.put({
+        id: record.id,
+        weight: record.weight,
+        date: record.date,
+      });
+    });
+
+    return new Promise((resolve, reject) => {
+      tx.oncomplete = () => {
+        this.onUpdated?.();
+        resolve(records.length);
+      };
+
+      tx.onerror = () =>
+        reject(tx.error || new Error("Failed to import weights."));
+      tx.onabort = () =>
+        reject(tx.error || new Error("Weight import transaction aborted."));
     });
   }
 
@@ -176,6 +207,8 @@ export function getBrowserWeightStorage(): IndexedDBWeightStorage {
 export const initDB = () => getBrowserWeightStorage().open();
 export const storeWeight = (id: string, weight: string) =>
   getBrowserWeightStorage().saveWeight(id, weight);
+export const importWeights = (records: WeightRecord[]) =>
+  getBrowserWeightStorage().importWeights(records);
 export const getWeight = (id: string) =>
   getBrowserWeightStorage().getLatestWeight(id);
 export const getAllWeights = () => getBrowserWeightStorage().listWeights();

--- a/src/styles.css
+++ b/src/styles.css
@@ -78,6 +78,11 @@ button {
   cursor: pointer;
 }
 
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
 *:focus-visible {
   outline: 2px solid var(--app-accent);
   outline-offset: 3px;
@@ -633,6 +638,12 @@ input::placeholder {
   padding: 0 12px;
 }
 
+.primary-action:disabled,
+.secondary-action:disabled {
+  background: var(--app-surface-soft);
+  color: var(--app-text-subdued);
+}
+
 .weight-badge {
   display: inline-flex;
   min-width: 0;
@@ -882,6 +893,44 @@ input::placeholder {
   position: relative;
   display: block;
   margin-bottom: 12px;
+}
+
+.history-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.history-actions__button {
+  width: 100%;
+}
+
+.history-actions__file {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
+}
+
+.history-actions__status {
+  min-height: 20px;
+  margin: 0 0 10px;
+  color: var(--app-text-muted);
+  font-size: 0.74rem;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
+.history-actions__status--success {
+  color: var(--app-primary);
+}
+
+.history-actions__status--error {
+  color: var(--app-danger);
 }
 
 .search-icon {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "4.1.0";
+export const APP_VERSION = "4.1.1";
 export const DB_NAME = "hiit-app-db";
 export const WEIGHT_STORE = "Weights";
 export const PROD_HOSTNAME = "yourfriendfitz.github.io";

--- a/tests/e2e/current-app.spec.js
+++ b/tests/e2e/current-app.spec.js
@@ -80,6 +80,40 @@ async function getLastWeightRecord(page) {
   });
 }
 
+async function clearWeightRecords(page) {
+  await page.evaluate(async () => {
+    const db = await new Promise((resolve, reject) => {
+      const request = indexedDB.open("hiit-app-db", 1);
+      request.onsuccess = () => resolve(request.result);
+      request.onerror = () => reject(request.error);
+    });
+    const tx = db.transaction("Weights", "readwrite");
+    const request = tx.objectStore("Weights").clear();
+    await new Promise((resolve, reject) => {
+      request.onsuccess = () => resolve();
+      request.onerror = () => reject(request.error);
+    });
+    db.close();
+  });
+}
+
+function createBackupFile(records) {
+  return {
+    name: "hiit-history-backup-2026-06-26.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(
+      JSON.stringify({
+        app: "hiit-web-app",
+        format: "weights-backup",
+        formatVersion: 1,
+        exportedAt: "2026-06-26T20:32:30.000Z",
+        recordCount: records.length,
+        records,
+      }),
+    ),
+  };
+}
+
 async function recordDirectoryScrollRequests(page) {
   await page.addInitScript(() => {
     window.directoryScrollRequests = [];
@@ -107,7 +141,7 @@ test("loads the current workout on app launch", async ({ page }) => {
     "Cycle Week 2/12 • Day 1",
   );
   await expect(page.locator(".exercise-card button").first()).toBeVisible();
-  await expect(page.locator("#versionIndicator")).toHaveText("v4.1.0");
+  await expect(page.locator("#versionIndicator")).toHaveText("v4.1.1");
 });
 
 test("adds and removes one recent missed workout from home", async ({
@@ -518,6 +552,95 @@ test("reads seeded history and filters it by exercise name", async ({
 
   await expect(page.getByText("Legacy 105")).toBeHidden();
   await expect(page.getByText("Legacy unknown 50")).toBeVisible();
+});
+
+test("imports a history backup and skips duplicate imports", async ({
+  page,
+}) => {
+  await page.goto("/#/history");
+
+  const backupFile = createBackupFile([
+    {
+      id: "45inclinebarbellpress",
+      weight: "Imported 95",
+      date: "2025-07-29T12:00:00.000Z",
+    },
+    {
+      id: "legextension",
+      weight: "Imported 70",
+      date: "2025-07-30T12:00:00.000Z",
+    },
+  ]);
+
+  await page.getByLabel("Import history backup").setInputFiles(backupFile);
+  await expect(
+    page.getByText("Imported 2 records. No duplicates skipped."),
+  ).toBeVisible();
+  await expect(page.getByText("Imported 95")).toBeVisible();
+  await expect(page.getByText("Imported 70")).toBeVisible();
+
+  await page.reload();
+  await expect(page.getByText("Imported 95")).toBeVisible();
+
+  await page.goto("/#/workout?week=0&day=0");
+  const firstExercise = page.locator(".exercise-card").first();
+  await firstExercise.locator("button").first().click();
+  await expect(
+    firstExercise.locator(".exercise-card__status .weight-badge"),
+  ).toContainText("Imported 95");
+
+  await page.goto("/#/history");
+
+  await page.getByLabel("Import history backup").setInputFiles(backupFile);
+  await expect(
+    page.getByText("Imported 0 records. Skipped 2 records."),
+  ).toBeVisible();
+  await expect(page.getByText("2 entries")).toHaveCount(0);
+  await expect(page.getByText("1 entry")).toHaveCount(2);
+});
+
+test("exports a history backup file", async ({
+  browserName,
+  page,
+}, testInfo) => {
+  test.skip(
+    browserName !== "chromium",
+    "Blob download coverage runs once in Chromium.",
+  );
+
+  await seedWeightRecords(page, [
+    {
+      id: "45inclinebarbellpress",
+      weight: "Exported 95",
+      date: "2025-07-29T12:00:00.000Z",
+    },
+    {
+      id: "legextension",
+      weight: "Exported 70",
+      date: "2025-07-30T12:00:00.000Z",
+    },
+  ]);
+
+  await page.goto("/#/history");
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByRole("button", { name: "Export" }).click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toMatch(
+    /^hiit-history-backup-\d{4}-\d{2}-\d{2}\.json$/,
+  );
+
+  const backupPath = testInfo.outputPath("history-backup.json");
+  await download.saveAs(backupPath);
+  await clearWeightRecords(page);
+  await page.reload();
+  await expect(page.getByText("No history yet")).toBeVisible();
+
+  await page.getByLabel("Import history backup").setInputFiles(backupPath);
+  await expect(
+    page.getByText("Imported 2 records. No duplicates skipped."),
+  ).toBeVisible();
+  await expect(page.getByText("Exported 95")).toBeVisible();
+  await expect(page.getByText("Exported 70")).toBeVisible();
 });
 
 test("cleans up database update listeners across route transitions", async ({

--- a/tests/pwa/offline.spec.js
+++ b/tests/pwa/offline.spec.js
@@ -80,6 +80,38 @@ test("loads core routes and saves a weight offline after the first visit", async
   await page.goto("/#/history");
   await expect(page.getByText(/Offline 145; 8 RPE\*/)).toBeVisible();
   await expect(page.getByText(/Offline added 125/)).toBeVisible();
+
+  await page.getByLabel("Import history backup").setInputFiles({
+    name: "offline-history-backup.json",
+    mimeType: "application/json",
+    buffer: Buffer.from(
+      JSON.stringify({
+        app: "hiit-web-app",
+        format: "weights-backup",
+        formatVersion: 1,
+        exportedAt: "2026-06-26T20:32:30.000Z",
+        recordCount: 1,
+        records: [
+          {
+            id: "legextension",
+            weight: "Offline imported 225",
+            date: "2025-08-03T12:00:00.000Z",
+          },
+        ],
+      }),
+    ),
+  });
+  await expect(
+    page.getByText("Imported 1 record. No duplicates skipped."),
+  ).toBeVisible();
+  await expect(page.getByText(/Offline imported 225/)).toBeVisible();
+
+  const downloadPromise = page.waitForEvent("download");
+  await page.getByRole("button", { name: "Export" }).click();
+  const download = await downloadPromise;
+  expect(download.suggestedFilename()).toMatch(
+    /^hiit-history-backup-\d{4}-\d{2}-\d{2}\.json$/,
+  );
 });
 
 test("legacy migration bridge removes stale shell caches without deleting IndexedDB history", async ({

--- a/tests/unit/history-backup.test.ts
+++ b/tests/unit/history-backup.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createWeightHistoryBackup,
+  getWeightHistoryBackupFileName,
+  parseWeightHistoryBackup,
+  planWeightHistoryImport,
+  serializeWeightHistoryBackup,
+  WeightHistoryBackupError,
+} from "../../src/history-backup";
+
+describe("history backup", () => {
+  it("serializes a versioned backup with normalized dates", () => {
+    const backup = createWeightHistoryBackup(
+      [
+        {
+          id: "row",
+          weight: "135",
+          date: new Date("2026-06-02T12:00:00.000Z"),
+        },
+        {
+          id: "press",
+          weight: "95",
+          date: "2026-06-01T12:00:00.000Z",
+        },
+      ],
+      "2026-06-26T20:32:30.000Z",
+    );
+
+    expect(backup).toEqual({
+      app: "hiit-web-app",
+      format: "weights-backup",
+      formatVersion: 1,
+      exportedAt: "2026-06-26T20:32:30.000Z",
+      recordCount: 2,
+      records: [
+        {
+          id: "press",
+          weight: "95",
+          date: "2026-06-01T12:00:00.000Z",
+        },
+        {
+          id: "row",
+          weight: "135",
+          date: "2026-06-02T12:00:00.000Z",
+        },
+      ],
+    });
+    expect(serializeWeightHistoryBackup(backup)).toContain(
+      '"format": "weights-backup"',
+    );
+  });
+
+  it("uses the export date in the backup filename", () => {
+    expect(getWeightHistoryBackupFileName("2026-06-26T20:32:30.000Z")).toBe(
+      "hiit-history-backup-2026-06-26.json",
+    );
+  });
+
+  it("parses a valid backup", () => {
+    const backup = parseWeightHistoryBackup(
+      JSON.stringify({
+        app: "hiit-web-app",
+        format: "weights-backup",
+        formatVersion: 1,
+        exportedAt: "2026-06-26T20:32:30.000Z",
+        recordCount: 1,
+        records: [
+          {
+            id: "press",
+            weight: "95",
+            date: "2026-06-01T12:00:00.000Z",
+          },
+        ],
+      }),
+    );
+
+    expect(backup.records).toEqual([
+      {
+        id: "press",
+        weight: "95",
+        date: "2026-06-01T12:00:00.000Z",
+      },
+    ]);
+  });
+
+  it("rejects malformed backups without returning partial records", () => {
+    expect(() => parseWeightHistoryBackup("{")).toThrow(
+      new WeightHistoryBackupError("Backup file is not valid JSON."),
+    );
+    expect(() =>
+      parseWeightHistoryBackup(
+        JSON.stringify({
+          app: "other-app",
+          format: "weights-backup",
+          formatVersion: 1,
+          exportedAt: "2026-06-26T20:32:30.000Z",
+          recordCount: 0,
+          records: [],
+        }),
+      ),
+    ).toThrow("different app");
+    expect(() =>
+      parseWeightHistoryBackup(
+        JSON.stringify({
+          app: "hiit-web-app",
+          format: "weights-backup",
+          formatVersion: 1,
+          exportedAt: "2026-06-26T20:32:30.000Z",
+          recordCount: 1,
+          records: [
+            {
+              id: "press",
+              weight: "95",
+              date: "not-a-date",
+            },
+          ],
+        }),
+      ),
+    ).toThrow("invalid date");
+  });
+
+  it("plans a merge-only import and skips exact duplicates", () => {
+    const importPlan = planWeightHistoryImport(
+      [
+        {
+          id: "press",
+          weight: "95",
+          date: new Date("2026-06-01T12:00:00.000Z"),
+        },
+      ],
+      [
+        {
+          id: "press",
+          weight: "95",
+          date: "2026-06-01T12:00:00.000Z",
+        },
+        {
+          id: "press",
+          weight: "105",
+          date: "2026-06-02T12:00:00.000Z",
+        },
+        {
+          id: "press",
+          weight: "105",
+          date: "2026-06-02T12:00:00.000Z",
+        },
+      ],
+    );
+
+    expect(importPlan).toEqual({
+      skippedDuplicates: 2,
+      recordsToImport: [
+        {
+          id: "press",
+          weight: "105",
+          date: "2026-06-02T12:00:00.000Z",
+        },
+      ],
+    });
+  });
+});

--- a/tests/unit/storage.test.ts
+++ b/tests/unit/storage.test.ts
@@ -169,4 +169,39 @@ describe("IndexedDBWeightStorage", () => {
 
     await expect(createStorage().listWeights()).resolves.toEqual(seededRecords);
   });
+
+  it("bulk imports legacy-compatible records without a schema migration", async () => {
+    const storage = createStorage();
+
+    await expect(
+      storage.importWeights([
+        {
+          id: "press",
+          weight: "Imported 95",
+          date: "2026-06-01T12:00:00.000Z",
+        },
+        {
+          id: "row",
+          weight: "Imported 135",
+          date: "2026-06-02T12:00:00.000Z",
+        },
+      ]),
+    ).resolves.toBe(2);
+
+    const db = await storage.open();
+    expect(db.version).toBe(DB_VERSION);
+    expect(Array.from(db.objectStoreNames)).toEqual([WEIGHT_STORE]);
+    await expect(storage.listWeights()).resolves.toEqual([
+      {
+        id: "press",
+        weight: "Imported 95",
+        date: "2026-06-01T12:00:00.000Z",
+      },
+      {
+        id: "row",
+        weight: "Imported 135",
+        date: "2026-06-02T12:00:00.000Z",
+      },
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary

- Add History export/import controls for local saved-weight backups.
- Add a versioned JSON backup format with validation and duplicate skipping.
- Add merge-only IndexedDB import that preserves the existing `hiit-app-db` version 1 / `Weights` / `{ id, weight, date }` contract.
- Document the iPhone old-PWA to new-PWA transfer workflow for the icon-refresh storage-container case.
- Bump app/package version to `4.1.1`.

## Verification

- `docker build -t hiit-web-app-checks .`
- `docker run --rm hiit-web-app-checks npm run lint`
- `docker run --rm hiit-web-app-checks npm run typecheck`
- `docker run --rm hiit-web-app-checks npm run test`
- Targeted changed-file Prettier check
- `docker run --rm hiit-web-app-checks npm run build`
- `docker run --rm hiit-web-app-checks npm run test:e2e`
- `docker run --rm hiit-web-app-checks npm run test:pwa`

## Notes

- Full global `format:check` still reports preexisting unrelated CRLF/format noise. The changed-file format check passed.
