### PR TITLE
v4.1.2 maintenance and previous-cycle planning

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.json]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto eol=lf
+
+*.ico binary
+*.png binary

--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ Confirm the `github-pages` environment deployment succeeds after each reviewed `
 
 Use the [release checklist](docs/releases/RELEASE-CHECKLIST.md) for the final refactor cutover. The [installed PWA migration runbook](docs/releases/PWA-MIGRATION.md) covers existing `v3.0.4` installs. The [rollback runbook](docs/releases/ROLLBACK.md) records the protected pre-refactor production baseline and recovery steps.
 
-- Current public release: [`v4.0.1`](docs/releases/v4.0.1.md).
-- Prepare the free-form weight-entry patch as [`v4.0.2`](docs/releases/v4.0.2.md).
-- Prepare the cycle-aware schedule and icon refresh as [`v4.1.0`](docs/releases/v4.1.0.md).
-- Prepare the History backup and restore patch as [`v4.1.1`](docs/releases/v4.1.1.md).
+- Current public release: [`v4.1.1`](docs/releases/v4.1.1.md).
+- Release notes: [`v4.0.2`](docs/releases/v4.0.2.md) free-form weight entry.
+- Published release notes: [`v4.1.0`](docs/releases/v4.1.0.md) cycle-aware schedule and icon refresh.
+- Published release notes: [`v4.1.1`](docs/releases/v4.1.1.md) History backup and restore.
 - Include user-visible changes, migration notes, and known issues.
 - Keep the legacy PWA migration bridge deployed until a later owner-approved cleanup.
 - Verify install and update behavior manually in iPhone Safari before publishing a release.

--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ Use the [release checklist](docs/releases/RELEASE-CHECKLIST.md) for the final re
 - Release notes: [`v4.0.2`](docs/releases/v4.0.2.md) free-form weight entry.
 - Published release notes: [`v4.1.0`](docs/releases/v4.1.0.md) cycle-aware schedule and icon refresh.
 - Published release notes: [`v4.1.1`](docs/releases/v4.1.1.md) History backup and restore.
+- Candidate release notes: [`v4.1.2`](docs/releases/v4.1.2.md) maintenance fixes and previous-cycle planning.
 - Include user-visible changes, migration notes, and known issues.
 - Keep the legacy PWA migration bridge deployed until a later owner-approved cleanup.
 - Verify install and update behavior manually in iPhone Safari before publishing a release.

--- a/docs/releases/v4.1.0.md
+++ b/docs/releases/v4.1.0.md
@@ -1,6 +1,8 @@
 # v4.1.0 Release Notes
 
-Status: Release candidate
+Status: Published
+
+Published tag: v4.1.0
 
 ## Summary
 

--- a/docs/releases/v4.1.1.md
+++ b/docs/releases/v4.1.1.md
@@ -1,6 +1,8 @@
 # v4.1.1 Release Notes
 
-Status: Release candidate
+Status: Published
+
+Published tag: v4.1.1
 
 ## Summary
 

--- a/docs/releases/v4.1.2.md
+++ b/docs/releases/v4.1.2.md
@@ -1,0 +1,68 @@
+# v4.1.2 Release Notes
+
+Status: Candidate
+
+Target tag: v4.1.2
+
+## Summary
+
+`v4.1.2` packages the maintenance fixes and planning work prepared after the
+History backup/restore release. It keeps the app storage-compatible while
+improving History ordering, weight-save failure feedback, release
+documentation, and future previous-cycle reference planning.
+
+## User-Visible Changes
+
+- Sort History entries by saved record date before marking an entry as
+  `Latest`.
+- Show visible feedback when a weight save fails.
+- Preserve typed weight input after a failed save so the user can retry.
+- Keep published release documentation aligned with the real `v4.1.0` and
+  `v4.1.1` tags.
+- Add proposed RFC/spec documentation for a future previous-cycle reference and
+  quick-fill workflow.
+
+## Implementation Notes
+
+- Repository line endings are normalized through `.editorconfig` and
+  `.gitattributes` so future diffs stay readable.
+- History latest-record selection now follows saved record dates instead of
+  depending on insertion/display order.
+- Weight-save errors stay inside the existing workout logging UI and do not
+  change the saved record format.
+- The previous-cycle reference work is design-only in this release; no
+  previous-cycle UI or storage migration is implemented.
+
+## Data And PWA Compatibility
+
+No IndexedDB schema or saved-weight migration is included:
+
+- Database: `hiit-app-db`
+- Database version: `1`
+- Store: `Weights`
+- Record shape: `{ id, weight, date }`
+- Legacy PWA bridge: retained at `/service-worker.js`
+- Generated Workbox worker: retained at `/sw.js`
+
+The proposed previous-cycle reference remains schema-compatible. Exact
+previous-cycle matching is not promised unless a future implementation can
+prove that confidence from existing records.
+
+## Verification
+
+Before publication:
+
+- Run the clean Docker lint, formatting, typecheck, unit, production build,
+  mobile Chromium/WebKit E2E, and offline PWA suites.
+- Confirm the visible footer, package metadata, E2E assertion, and release notes
+  all use `v4.1.2`.
+- Confirm History still marks the newest saved record as `Latest` after older
+  records are imported.
+- Confirm failed weight saves show feedback and preserve typed input.
+- Confirm previous-cycle reference and quick-fill docs are present but no
+  previous-cycle UI has shipped.
+
+## Rollback
+
+Follow [`ROLLBACK.md`](./ROLLBACK.md). This release does not require a database
+migration or cleanup.

--- a/docs/rfcs/0003-previous-cycle-reference-and-quick-fill.md
+++ b/docs/rfcs/0003-previous-cycle-reference-and-quick-fill.md
@@ -1,0 +1,229 @@
+# RFC 0003: Previous-Cycle Reference And Quick Fill
+
+Status: Proposed
+
+Owner: Fitz
+
+Created: 2026-07-03
+
+Target release: `v4.1.2`
+
+## Summary
+
+Add a conservative previous-weight reference and quick-fill improvement to the
+workout logging flow. The feature should help users reuse a prior logged value
+without retyping it, while keeping the existing local-only IndexedDB data
+contract unchanged.
+
+`v4.1.2` remains schema-compatible. It may show the previous logged value and
+may use previous-cycle candidate wording only when the existing data supports
+that level of confidence. Existing records do not contain the scheduled
+workout week/day that produced the save, so exact previous-cycle matching is
+not guaranteed from current storage alone.
+
+## Problem Statement
+
+Workout cards already show the latest saved weight for an exercise, but the
+user must manually copy that value into the input before saving a new entry.
+The saved value also includes a trailing bracketed details suffix added by the
+app, for example:
+
+```text
+185 [Sets: 3, Reps: 8, Early RPE: 8, Last RPE: 9]
+```
+
+That suffix is useful in History, but it is noisy when the user wants to reuse
+only the typed weight value.
+
+The schedule now repeats in 12-week cycles, which makes a previous-cycle
+reference useful. However, the current `WeightRecord` only stores `{ id, weight,
+date }`. Because the `date` is the save timestamp, not the scheduled workout
+date, missed workout logging can make save-date-derived previous cycle matches
+ambiguous.
+
+## Goals
+
+- Add an explicit quick-fill action for prior logged values on workout cards.
+- Copy only the user-entered value portion before a trailing bracketed details
+  suffix when the value follows the current saved format.
+- Preserve a sensible fallback for legacy free-text weight values that do not
+  follow the bracketed suffix format.
+- Keep the existing latest-weight behavior intact for exercise IDs.
+- Allow previous-cycle candidate wording only when the app can explain the
+  confidence from existing records.
+- Keep the database `hiit-app-db` at version `1`.
+- Keep the object store `Weights` and record shape `{ id, weight, date }`.
+- Work offline in the installed PWA.
+- Add tests for value extraction, user-initiated quick fill, ambiguous
+  previous-cycle behavior, and unchanged storage compatibility.
+
+## Non-Goals
+
+- Do not add cloud sync, accounts, or a backend.
+- Do not migrate IndexedDB or add a new object store.
+- Do not append hidden metadata to the free-text `weight` field.
+- Do not change the shape of `WeightRecord`.
+- Do not promise exact previous-cycle matching when existing records cannot
+  prove the scheduled workout that created them.
+- Do not automatically populate or overwrite the input without a direct user
+  tap.
+- Do not change workout data, exercise IDs, or exercise metadata.
+- Do not remove the bracketed details suffix from newly saved History records.
+
+## Proposed Direction
+
+Keep the feature inside the current workout logging flow:
+
+- Continue reading the latest stored record for each exercise through the
+  storage boundary.
+- Show the existing last logged reference when a value exists.
+- Add a compact `Use` action near the reference.
+- On direct tap, copy the reusable value into the input.
+- If the stored value ends with the app-generated bracketed details suffix,
+  copy only the text before that suffix.
+- If the stored value is legacy free text without a recognizable suffix, copy
+  the full stored value after trimming surrounding whitespace.
+- If the user already typed into the field, require the same direct tap and
+  treat the tap as an intentional replace action.
+
+Previous-cycle wording should be conservative:
+
+- `Last logged` is safe when the app is showing the latest saved record for the
+  same exercise ID.
+- `Previous cycle` is allowed only for a candidate that can be derived with
+  clear confidence from existing data and schedule context.
+- If missed workout behavior or save-date ambiguity prevents confidence, the UI
+  should stay with `Last logged` or similar neutral wording.
+
+This avoids creating a false promise that the app can reconstruct exact
+scheduled-cycle history from records that only contain exercise ID, free-text
+weight, and save date.
+
+## UX Wording
+
+Recommended copy:
+
+- Section label: `Last logged weight`
+- Badge label when present: `Last logged`
+- Quick-fill button: `Use`
+- Candidate label when confidence is strong enough: `Previous cycle`
+- Empty state: `No previous`
+
+Examples:
+
+- Stored current-format value:
+  `185 [Sets: 3, Reps: 8, Early RPE: 8, Last RPE: 9]`
+- Button label or accessible name may communicate: `Use 185`
+- Input value after tap: `185`
+- Legacy value without a trailing bracketed suffix:
+  `40s; RPE 9*`
+- Input value after tap: `40s; RPE 9*`
+
+The UI should not imply that quick fill has saved anything. The existing Save
+button remains the only action that writes a new record.
+
+## Data And Storage Impact
+
+No schema migration is planned.
+
+- Database: `hiit-app-db`
+- Version: `1`
+- Store: `Weights`
+- Record shape: `{ id, weight, date }`
+
+The feature reads existing `WeightRecord` values and writes through the current
+save path only after the user taps Save. It must not add hidden metadata to
+`weight`, create a new store, or require a new IndexedDB version.
+
+Because `date` is a save timestamp, not a scheduled workout timestamp, previous
+cycle matching cannot be exact for all records. Missed workout logging can
+place a record on a later calendar date than the workout it represents.
+
+## Offline And PWA Impact
+
+The feature uses local React state and the existing IndexedDB store. It should
+work after the app shell is cached and the installed PWA is offline.
+
+No service-worker strategy change is expected. The generated Workbox worker and
+the legacy `public/service-worker.js` migration bridge should remain unchanged.
+
+## Implementation Notes
+
+- Keep `src/storage.ts` as the IndexedDB boundary.
+- Prefer a small pure helper for extracting the reusable value from saved
+  `weight` strings.
+- Recognize only a trailing bracketed details suffix that matches the current
+  app-generated format closely enough to avoid trimming intentional user text.
+- Treat legacy free-text records as user-authored values and copy them whole.
+- Keep `src/program-schedule.ts` responsible for cycle math if candidate
+  labeling needs schedule context.
+- Keep `src/components/workout.tsx` responsible for rendering the reference,
+  quick-fill action, and input state.
+- Do not add storage writes until the user presses Save.
+- Do not clear or bypass existing PWA dirty-input protection.
+
+## Acceptance Criteria
+
+- Workout cards with a prior value show a last logged reference.
+- A visible, direct `Use` action copies the reusable value into the weight
+  input.
+- Quick fill copies only the value before the trailing bracketed details suffix
+  for current-format saved records.
+- Quick fill copies the full trimmed value for legacy free-text records without
+  a recognizable suffix.
+- Quick fill does not save a record by itself.
+- Quick fill does not overwrite typed input without a direct user tap.
+- Previous-cycle wording appears only when the implementation can support it
+  with confident data.
+- Ambiguous missed workout cases use neutral wording such as `Last logged`.
+- The IndexedDB database remains `hiit-app-db`, version `1`, store `Weights`,
+  with `{ id, weight, date }` records.
+- Offline installed-PWA behavior remains unchanged.
+
+## Tests
+
+- Unit tests cover extracting the reusable value from current-format saved
+  strings with `[Sets: ...]` details.
+- Unit tests cover legacy free-text fallback values.
+- Unit tests cover any previous-cycle candidate helper, including missed
+  workout ambiguity.
+- Storage tests verify the database name, version, store, and `WeightRecord`
+  shape stay unchanged.
+- E2E tests cover tapping `Use`, seeing the input populate, and confirming no
+  save occurs until Save is tapped.
+- E2E tests cover preserving typed input until the user directly chooses quick
+  fill.
+- Existing workout save and History display tests remain passing.
+
+## Manual QA
+
+- Open a workout with saved history and confirm the last logged reference is
+  visible.
+- Tap `Use` for a current-format saved value and confirm only the value before
+  `[Sets:` appears in the input.
+- Save the quick-filled value and confirm the new History entry still includes
+  the normal bracketed details suffix.
+- Test a legacy free-text record and confirm quick fill copies the full trimmed
+  value.
+- Type into the input first, then tap `Use`, and confirm the replace only
+  happens because of that tap.
+- Verify ambiguous missed workout history does not receive exact
+  `Previous cycle` wording.
+- Repeat the flow while the installed PWA is service-worker controlled and
+  offline.
+
+## Rollback
+
+Revert the workout quick-fill UI, value-extraction helper, schedule candidate
+helper if added, tests, and docs. No database cleanup should be required
+because the feature does not migrate schema or write records outside the
+existing Save path.
+
+## Open Questions
+
+- What confidence rule, if any, is acceptable for showing `Previous cycle`
+  instead of `Last logged` in `v4.1.2`?
+- Should the `Use` action be visible only on expanded exercise cards, or also
+  near compact last logged badges?
+- Should replacing typed input show a confirmation affordance, or is the
+  direct tap enough?

--- a/docs/specs/0011-previous-cycle-reference-and-quick-fill.md
+++ b/docs/specs/0011-previous-cycle-reference-and-quick-fill.md
@@ -1,0 +1,198 @@
+# Milestone 11 Spec: Previous-Cycle Reference And Quick Fill
+
+Status: Proposed
+
+Owner: Fitz
+
+Created: 2026-07-03
+
+Related RFC: [`RFC 0003`](../rfcs/0003-previous-cycle-reference-and-quick-fill.md)
+
+Related ADRs:
+
+- [`ADR 0003`](../adr/0003-indexeddb-preservation.md)
+
+## Summary
+
+Implement the `v4.1.2` previous-weight reference and quick-fill improvement for
+workout cards. The feature should let users copy a prior logged value into the
+current weight input with an explicit tap, while preserving the existing
+IndexedDB schema and avoiding overconfident previous-cycle claims.
+
+The implementation must keep the app local-only, offline-capable, and
+compatible with existing `WeightRecord` data.
+
+## Goals
+
+- Show a useful prior-value reference on workout exercise cards.
+- Add an explicit `Use` action that quick-fills the weight input.
+- Extract only the user-entered value before the app-generated trailing
+  bracketed details suffix when possible.
+- Preserve legacy free-text fallback behavior.
+- Use `Previous cycle` wording only when matching can be confidently derived.
+- Keep ambiguous missed workout cases on neutral wording such as `Last logged`.
+- Keep the database `hiit-app-db` at version `1`.
+- Keep the object store `Weights` and record shape `{ id, weight, date }`.
+- Preserve offline installed-PWA behavior.
+- Add targeted unit and E2E coverage for quick fill and compatibility.
+
+## Non-Goals
+
+- Do not add cloud sync, accounts, or a backend.
+- Do not change workout programming, exercise IDs, or exercise metadata.
+- Do not migrate IndexedDB.
+- Do not add hidden metadata to the free-text `weight` field.
+- Do not guarantee exact previous-cycle matching from save-date-only records.
+- Do not automatically fill or overwrite the input without a direct user tap.
+- Do not change the normal saved History format that appends workout details.
+
+## Scope
+
+- Add a pure helper for reusable-weight extraction from saved `weight` strings.
+- Update the workout card logging UI to render a direct quick-fill action.
+- Add or adjust schedule helper logic only if previous-cycle candidate wording
+  can be supported without schema changes.
+- Add unit tests for extraction, candidate ambiguity, and unchanged storage
+  contracts.
+- Add E2E coverage for the quick-fill interaction.
+- Update docs for `v4.1.2` behavior if a release note is created separately by
+  the reviewer.
+
+## User Impact
+
+Users can tap `Use` on a prior value instead of manually retyping or selecting
+text from the last logged badge. Current-format saved entries quick-fill only
+the value they originally typed, not the appended `[Sets: ...]` details.
+
+Users should not see misleading precision. If the app cannot prove a previous
+cycle candidate because of missed workout or save-date ambiguity, it should
+present the value as `Last logged` rather than `Previous cycle`.
+
+## Architecture Impact
+
+Expected modules:
+
+- `src/storage.ts`: remain the IndexedDB boundary and keep existing reads and
+  writes compatible.
+- `src/components/workout.tsx`: render the last logged reference, `Use` action,
+  and quick-fill state updates.
+- `src/program-schedule.ts`: own cycle math or candidate helper behavior if
+  previous-cycle wording is implemented.
+- `tests/unit/storage.test.ts`: verify the unchanged database contract.
+- `tests/unit/program-schedule.test.ts`: cover candidate matching or ambiguity
+  rules if schedule helpers change.
+- `tests/e2e/current-app.spec.js`: cover the browser quick-fill flow.
+
+The value extraction helper can live near the workout component or in a small
+utility module if tests need direct import. Keep the abstraction narrow.
+
+## Data And Storage Impact
+
+Hard data constraint:
+
+- Database: `hiit-app-db`
+- Version: `1`
+- Store: `Weights`
+- Record shape: `{ id, weight, date }`
+
+No schema migration is allowed. The feature reads existing records and writes
+only through the current user-initiated Save path. It must not append hidden
+metadata to free-text weight values or depend on a new stored workout-week
+field.
+
+Because existing records store save dates, exact previous-cycle matching is not
+derivable for all cases. A missed workout saved later can look like a different
+scheduled workout if the implementation relies only on `date`.
+
+## Offline And PWA Impact
+
+Quick fill is local UI state plus existing IndexedDB reads. It should work in a
+service-worker-controlled PWA while offline after the app has already cached
+the shell.
+
+No Workbox strategy, manifest, icon, or legacy `public/service-worker.js`
+migration bridge change is expected.
+
+## Files Likely Touched
+
+- `src/storage.ts`
+- `src/components/workout.tsx`
+- `src/program-schedule.ts`
+- `tests/unit/storage.test.ts`
+- `tests/unit/program-schedule.test.ts`
+- `tests/e2e/current-app.spec.js`
+
+Optional if the implementation uses a separate helper:
+
+- `src/weight-format.ts`
+- `tests/unit/weight-format.test.ts`
+
+## Acceptance Criteria
+
+- Workout cards still show prior saved values for the same exercise ID.
+- A direct `Use` action appears when a reusable prior value is available.
+- Tapping `Use` populates the input with the reusable value.
+- Current-format saved values copy only the text before the trailing
+  `[Sets: ...]` details suffix.
+- Legacy free-text values without a recognizable suffix copy as full trimmed
+  text.
+- Quick fill does not create or update a record until Save is tapped.
+- Quick fill does not overwrite existing typed input without a direct tap.
+- Ambiguous previous-cycle candidates use `Last logged` or another neutral
+  label instead of `Previous cycle`.
+- The database contract remains `hiit-app-db`, version `1`, store `Weights`,
+  record shape `{ id, weight, date }`.
+- Existing History, backup/restore, and last logged behavior remain compatible.
+
+## Regression Tests
+
+- Unit tests cover reusable-value extraction from strings with `[Sets:` details.
+- Unit tests cover legacy free-text fallback, empty strings, and bracketed text
+  that should not be trimmed.
+- Storage tests cover `DB_VERSION === 1`, `DB_NAME === "hiit-app-db"`, store
+  `Weights`, and `WeightRecord` compatibility.
+- Program schedule tests cover any helper used for previous-cycle candidates,
+  including missed workout ambiguity.
+- E2E tests cover tapping `Use`, verifying the input value, saving afterward,
+  and seeing the saved History entry retain details.
+- E2E tests cover no automatic overwrite before the user taps `Use`.
+
+## Manual QA
+
+- Seed or create a saved value such as
+  `185 [Sets: 3, Reps: 8, Early RPE: 8, Last RPE: 9]`.
+- Open the same exercise and confirm the prior value appears.
+- Tap `Use` and confirm the input contains `185`.
+- Save and confirm History shows a normal details-appended value.
+- Repeat with a legacy value such as `40s; RPE 9*` and confirm the full value
+  copies.
+- Type a different value first, tap `Use`, and confirm replacement only happens
+  after the tap.
+- Confirm ambiguous missed workout data does not show exact `Previous cycle`
+  wording.
+- Repeat while the installed PWA is offline after one controlled online load.
+
+## Rollback
+
+Revert the quick-fill UI, value extraction helper, optional schedule candidate
+helper, and related tests. No database rollback should be required because the
+feature keeps the same schema and only saves through the existing Save action.
+
+## Open Questions
+
+- What evidence is sufficient to label a value as `Previous cycle` in
+  `v4.1.2`?
+- Should quick fill be disabled when the input is non-empty, or is direct-tap
+  replacement acceptable?
+- Should the compact last logged badge and full training-log reference expose
+  the same quick-fill control?
+
+## Implementation STOP Gates
+
+Stop implementation and return to RFC/spec review if any of these become true:
+
+- Exact previous-cycle matching is required but not derivable from existing
+  `{ id, weight, date }` records.
+- A DB schema migration is required.
+- Hidden metadata would need to be appended to the free-text `weight` value.
+- Quick fill would overwrite typed input without a direct user tap.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hiit-web-app",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hiit-web-app",
-      "version": "4.1.1",
+      "version": "4.1.2",
       "dependencies": {
         "lucide-react": "^1.17.0",
         "react": "^19.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hiit-web-app",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "private": true,
   "description": "HIIT Workout Web App",
   "engines": {

--- a/src/components/history.tsx
+++ b/src/components/history.tsx
@@ -37,20 +37,7 @@ function compareWeightRecordsByNewest(
   first: WeightRecord,
   second: WeightRecord,
 ) {
-  const dateDifference =
-    new Date(second.date).getTime() - new Date(first.date).getTime();
-
-  if (dateDifference !== 0) {
-    return dateDifference;
-  }
-
-  const weightDifference = first.weight.localeCompare(second.weight);
-
-  if (weightDifference !== 0) {
-    return weightDifference;
-  }
-
-  return first.id.localeCompare(second.id);
+  return new Date(second.date).getTime() - new Date(first.date).getTime();
 }
 
 export function HistoryPage({ exercises }: { exercises: ExerciseMetadata[] }) {

--- a/src/components/history.tsx
+++ b/src/components/history.tsx
@@ -33,6 +33,26 @@ function describeRecordCount(count: number) {
   return `${count} ${count === 1 ? "record" : "records"}`;
 }
 
+function compareWeightRecordsByNewest(
+  first: WeightRecord,
+  second: WeightRecord,
+) {
+  const dateDifference =
+    new Date(second.date).getTime() - new Date(first.date).getTime();
+
+  if (dateDifference !== 0) {
+    return dateDifference;
+  }
+
+  const weightDifference = first.weight.localeCompare(second.weight);
+
+  if (weightDifference !== 0) {
+    return weightDifference;
+  }
+
+  return first.id.localeCompare(second.id);
+}
+
 export function HistoryPage({ exercises }: { exercises: ExerciseMetadata[] }) {
   const [weights, setWeights] = useState<WeightRecord[]>([]);
   const [filter, setFilter] = useState("");
@@ -72,7 +92,7 @@ export function HistoryPage({ exercises }: { exercises: ExerciseMetadata[] }) {
         .includes(normalizedFilter),
     );
 
-    return filteredWeights.reduce<Record<string, WeightRecord[]>>(
+    const groups = filteredWeights.reduce<Record<string, WeightRecord[]>>(
       (groups, weight) => {
         groups[weight.id] = groups[weight.id] || [];
         groups[weight.id].push(weight);
@@ -80,6 +100,12 @@ export function HistoryPage({ exercises }: { exercises: ExerciseMetadata[] }) {
       },
       {},
     );
+
+    Object.values(groups).forEach((entries) => {
+      entries.sort(compareWeightRecordsByNewest);
+    });
+
+    return groups;
   }, [exerciseMap, filter, weights]);
 
   const groupIds = Object.keys(groupedWeights);
@@ -263,37 +289,31 @@ export function HistoryPage({ exercises }: { exercises: ExerciseMetadata[] }) {
                 >
                   <div className="accordion-content__inner">
                     <div className="accordion-body">
-                      {entries
-                        .slice()
-                        .reverse()
-                        .map((weight, index) => (
-                          <div
-                            className={`weight-entry ${index === 0 ? "latest" : ""}`}
-                            key={`${weight.id}-${String(weight.date)}-${index}`}
-                          >
-                            <div className="weight-entry__value">
-                              <span className="weight-number">
-                                {weight.weight}
-                              </span>
-                              {index === 0 ? (
-                                <span className="latest-badge">Latest</span>
-                              ) : null}
-                            </div>
-                            <div className="weight-date">
-                              {new Date(weight.date).toLocaleDateString(
-                                "en-US",
-                                {
-                                  weekday: "short",
-                                  month: "short",
-                                  day: "numeric",
-                                  year: "numeric",
-                                  hour: "numeric",
-                                  minute: "2-digit",
-                                },
-                              )}
-                            </div>
+                      {entries.map((weight, index) => (
+                        <div
+                          className={`weight-entry ${index === 0 ? "latest" : ""}`}
+                          key={`${weight.id}-${String(weight.date)}-${index}`}
+                        >
+                          <div className="weight-entry__value">
+                            <span className="weight-number">
+                              {weight.weight}
+                            </span>
+                            {index === 0 ? (
+                              <span className="latest-badge">Latest</span>
+                            ) : null}
                           </div>
-                        ))}
+                          <div className="weight-date">
+                            {new Date(weight.date).toLocaleDateString("en-US", {
+                              weekday: "short",
+                              month: "short",
+                              day: "numeric",
+                              year: "numeric",
+                              hour: "numeric",
+                              minute: "2-digit",
+                            })}
+                          </div>
+                        </div>
+                      ))}
                     </div>
                   </div>
                 </div>

--- a/src/components/workout.tsx
+++ b/src/components/workout.tsx
@@ -35,6 +35,17 @@ function showSavedToast() {
   }).showToast();
 }
 
+function showSaveFailedToast() {
+  Toastify({
+    text: "Weight save failed",
+    duration: 2500,
+    gravity: "bottom",
+    position: "center",
+    stopOnFocus: true,
+    className: "toastify",
+  }).showToast();
+}
+
 function useLastWeight(exerciseId: string) {
   const [weight, setWeight] = useState("");
   const requestSequence = useRef(0);
@@ -43,11 +54,13 @@ function useLastWeight(exerciseId: string) {
     let active = true;
     const update = () => {
       const sequence = ++requestSequence.current;
-      void getWeight(exerciseId).then((latestWeight) => {
-        if (active && sequence === requestSequence.current) {
-          setWeight(latestWeight);
-        }
-      });
+      void getWeight(exerciseId)
+        .then((latestWeight) => {
+          if (active && sequence === requestSequence.current) {
+            setWeight(latestWeight);
+          }
+        })
+        .catch(() => undefined);
     };
 
     update();
@@ -114,6 +127,8 @@ function WeightLogger({
   latestWeight: string;
 }) {
   const [weight, setWeight] = useState("");
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState("");
   const weightInputId = `weight-${exerciseInstanceId}`;
 
   useEffect(
@@ -122,17 +137,29 @@ function WeightLogger({
   );
 
   const saveWeight = async () => {
-    if (!weight) {
+    if (!weight || isSaving) {
       return;
     }
 
     const earlyRpe = exercise.earlyRpe ?? "N/A";
     const lastRpe = exercise.lastRpe ?? "N/A";
     const weightWithDetails = `${weight} [Sets: ${exercise.workingSets}, Reps: ${exercise.repsOrDuration}, Early RPE: ${earlyRpe}, Last RPE: ${lastRpe}]`;
-    await storeWeight(exercise.id, weightWithDetails);
-    showSavedToast();
-    setWeight("");
-    pwaUpdatePolicy.clearInput(weightInputId);
+    setIsSaving(true);
+    setSaveError("");
+
+    try {
+      await storeWeight(exercise.id, weightWithDetails);
+      showSavedToast();
+      setWeight("");
+      pwaUpdatePolicy.clearInput(weightInputId);
+      setSaveError("");
+    } catch {
+      setSaveError("Weight was not saved. Try again.");
+      pwaUpdatePolicy.setInputDirty(weightInputId, true);
+      showSaveFailedToast();
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   return (
@@ -163,11 +190,21 @@ function WeightLogger({
             pwaUpdatePolicy.setInputDirty(weightInputId, nextWeight !== "");
           }}
         />
-        <button type="button" className="primary-action" onClick={saveWeight}>
+        <button
+          type="button"
+          className="primary-action"
+          onClick={saveWeight}
+          disabled={isSaving}
+        >
           <Save size={18} strokeWidth={2.5} aria-hidden="true" />
           <span>Save</span>
         </button>
       </div>
+      {saveError ? (
+        <p className="weight-logger__error" role="status">
+          {saveError}
+        </p>
+      ) : null}
     </section>
   );
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -585,6 +585,14 @@ button:disabled {
   grid-template-columns: minmax(0, 1fr) auto;
 }
 
+.weight-logger__error {
+  margin: 0;
+  color: var(--app-danger);
+  font-size: 0.74rem;
+  font-weight: 700;
+  line-height: 1.4;
+}
+
 input[type="text"],
 input[type="search"] {
   width: 100%;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export const APP_VERSION = "4.1.1";
+export const APP_VERSION = "4.1.2";
 export const DB_NAME = "hiit-app-db";
 export const WEIGHT_STORE = "Weights";
 export const PROD_HOSTNAME = "yourfriendfitz.github.io";

--- a/tests/e2e/current-app.spec.js
+++ b/tests/e2e/current-app.spec.js
@@ -141,7 +141,7 @@ test("loads the current workout on app launch", async ({ page }) => {
     "Cycle Week 2/12 • Day 1",
   );
   await expect(page.locator(".exercise-card button").first()).toBeVisible();
-  await expect(page.locator("#versionIndicator")).toHaveText("v4.1.1");
+  await expect(page.locator("#versionIndicator")).toHaveText("v4.1.2");
 });
 
 test("adds and removes one recent missed workout from home", async ({

--- a/tests/e2e/current-app.spec.js
+++ b/tests/e2e/current-app.spec.js
@@ -685,6 +685,41 @@ test("keeps newer local history marked latest after importing older records", as
   await expect(olderImportedEntry).not.toContainText("Latest");
 });
 
+test("preserves same-timestamp history order when marking latest", async ({
+  page,
+}) => {
+  await seedWeightRecords(page, [
+    {
+      id: "45inclinebarbellpress",
+      weight: "Same time first 105",
+      date: "2025-08-10T12:00:00.000Z",
+    },
+    {
+      id: "45inclinebarbellpress",
+      weight: "Same time second 95",
+      date: "2025-08-10T12:00:00.000Z",
+    },
+  ]);
+
+  await page.goto("/#/history");
+
+  const exerciseGroup = page.locator(".accordion-item").filter({
+    hasText: "45° Incline Barbell Press",
+  });
+  await exerciseGroup
+    .getByRole("button", { name: /45° Incline Barbell Press/ })
+    .click();
+
+  const entries = exerciseGroup.locator(".weight-entry");
+  await expect(entries).toHaveCount(2);
+  await expect(entries.first()).toContainText("Same time first 105");
+  await expect(entries.first()).toContainText("Latest");
+
+  const secondEntry = entries.filter({ hasText: "Same time second 95" });
+  await expect(secondEntry).toBeVisible();
+  await expect(secondEntry).not.toContainText("Latest");
+});
+
 test("exports a history backup file", async ({
   browserName,
   page,

--- a/tests/e2e/current-app.spec.js
+++ b/tests/e2e/current-app.spec.js
@@ -599,6 +599,49 @@ test("imports a history backup and skips duplicate imports", async ({
   await expect(page.getByText("1 entry")).toHaveCount(2);
 });
 
+test("keeps newer local history marked latest after importing older records", async ({
+  page,
+}) => {
+  await seedWeightRecords(page, [
+    {
+      id: "45inclinebarbellpress",
+      weight: "Newer local 105",
+      date: "2025-08-10T12:00:00.000Z",
+    },
+  ]);
+
+  await page.goto("/#/history");
+
+  const backupFile = createBackupFile([
+    {
+      id: "45inclinebarbellpress",
+      weight: "Older imported 95",
+      date: "2025-07-29T12:00:00.000Z",
+    },
+  ]);
+
+  await page.getByLabel("Import history backup").setInputFiles(backupFile);
+  await expect(
+    page.getByText("Imported 1 record. No duplicates skipped."),
+  ).toBeVisible();
+
+  const exerciseGroup = page.locator(".accordion-item").filter({
+    hasText: "45° Incline Barbell Press",
+  });
+  await exerciseGroup
+    .getByRole("button", { name: /45° Incline Barbell Press/ })
+    .click();
+
+  const entries = exerciseGroup.locator(".weight-entry");
+  await expect(entries).toHaveCount(2);
+  await expect(entries.first()).toContainText("Newer local 105");
+  await expect(entries.first()).toContainText("Latest");
+
+  const olderImportedEntry = entries.filter({ hasText: "Older imported 95" });
+  await expect(olderImportedEntry).toBeVisible();
+  await expect(olderImportedEntry).not.toContainText("Latest");
+});
+
 test("exports a history backup file", async ({
   browserName,
   page,

--- a/tests/e2e/current-app.spec.js
+++ b/tests/e2e/current-app.spec.js
@@ -476,6 +476,49 @@ test("saves a free-text weight and shows it in history", async ({ page }) => {
   await expect(page.getByText(/40s; 9 for 95 9 RPE\*/)).toBeVisible();
 });
 
+test("shows feedback and preserves input when a weight save fails", async ({
+  page,
+}) => {
+  const pageErrors = [];
+  page.on("pageerror", (error) => {
+    pageErrors.push(error.message);
+  });
+
+  await page.goto("/#/workout?week=0&day=0");
+
+  const firstExercise = page.locator(".exercise-card").first();
+  await firstExercise.locator("button").first().click();
+  const weightInput = firstExercise.locator('input[id^="weight-"]');
+  await weightInput.fill("Will fail 100");
+
+  await page.evaluate(() => {
+    const originalTransaction = IDBDatabase.prototype.transaction;
+    window.restoreTransactions = () => {
+      IDBDatabase.prototype.transaction = originalTransaction;
+      delete window.restoreTransactions;
+    };
+    IDBDatabase.prototype.transaction = () => {
+      throw new Error("Forced transaction failure");
+    };
+  });
+
+  try {
+    await firstExercise.getByRole("button", { name: "Save" }).click();
+
+    await expect(
+      firstExercise.getByText("Weight was not saved. Try again."),
+    ).toBeVisible();
+    await expect(page.getByText("Weight save failed")).toBeVisible();
+    await expect(page.getByText("Weight saved", { exact: true })).toHaveCount(
+      0,
+    );
+    await expect(weightInput).toHaveValue("Will fail 100");
+    expect(pageErrors).toEqual([]);
+  } finally {
+    await page.evaluate(() => window.restoreTransactions?.());
+  }
+});
+
 test("stores stable context when optional RPE fields are absent", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- normalize repository line endings with editor configuration
- sort History records by saved record date before marking Latest
- show visible save-failure feedback and preserve typed weight input
- correct published release documentation for v4.1.0 and v4.1.1
- add RFC/spec docs for previous-cycle reference and quick fill planning

## Verification
- docker run --rm hiit-web-app-checks

## Notes
- Previous-cycle quick fill is documented as a proposed v4.1.2 design, not implemented in this PR.
